### PR TITLE
Move GSD CHEM plume rise code to GOCART repo

### DIFF
--- a/Process_Library/Chem_MieTableMod2G.F90
+++ b/Process_Library/Chem_MieTableMod2G.F90
@@ -9,7 +9,10 @@
 
 ! !USES:
    implicit none
+
+#ifdef HAS_NETCDF3
    include "netcdf.inc"    ! Required for Mie tables stored as NCDF files
+#endif
 
 ! !PUBLIC TYPES:
 !

--- a/Process_Library/gsd_chem_config.F90
+++ b/Process_Library/gsd_chem_config.F90
@@ -1,0 +1,280 @@
+!
+! Haiqin.Li@noaa.gov  
+! 01/2020
+! constant parameters and chemistry configurations and tracers
+! (This will be splited into three subroutine for configuration, constant and tracers later)
+! 08/2020 move configuration into chem nml
+!
+module gsd_chem_config
+
+  use gsd_chem_constants, only : kind_chem
+
+  implicit none
+
+  !-- constant paramters
+  real(kind=kind_chem), parameter :: epsilc     = 1.e-16
+
+  !-- chemistyr module configurations
+  integer :: chem_opt = 300
+  integer :: kemit = 1
+  integer :: dust_opt = 5
+  integer :: dmsemis_opt = 1
+  integer :: seas_opt = 2
+  integer :: biomass_burn_opt=1
+  integer :: plumerise_flag = 2  ! 1=MODIS, 2=GBBEPx
+  integer :: plumerisefire_frq=60
+  integer :: chem_conv_tr  = 0
+  integer :: aer_ra_feedback=1 !0
+  integer :: aer_ra_frq=60
+  integer :: wetdep_ls_opt = 1
+
+  real(kind=kind_chem), parameter :: depo_fact=0.
+  integer, parameter :: CHEM_OPT_GOCART= 300
+  integer, parameter :: CHEM_OPT_GOCART_RACM  = 301
+  integer, parameter :: CHEM_OPT_RACM_SOA_VBS = 108
+  INTEGER, PARAMETER :: gocartracm_kpp = 301
+  integer, parameter :: chem_tune_tracers = 20
+  integer, parameter :: CHEM_OPT_MAX      = 500
+  integer, parameter :: DUST_OPT_NONE = 0
+  integer, parameter :: SEAS_OPT_NONE = 0
+  ! -- DMS emissions
+  integer, parameter :: DMSE_OPT_NONE   = 0
+  integer, parameter :: DMSE_OPT_ENABLE = 1
+  ! -- subgrid convective transport
+  integer, parameter :: CTRA_OPT_NONE  = 0
+  integer, parameter :: CTRA_OPT_GRELL = 2
+  ! -- large scale wet deposition
+  integer, parameter :: WDLS_OPT_NONE  = 0
+  integer, parameter :: WDLS_OPT_GSD   = 1
+  integer, parameter :: WDLS_OPT_NGAC  = 2
+
+  ! --
+  integer, parameter :: call_chemistry     = 1
+  integer, parameter :: num_ebu            = 7
+  integer, parameter :: num_ebu_in         = 7
+  integer, parameter :: num_moist=3, num_chem=20, num_emis_seas=5, num_emis_dust=5
+  integer, parameter :: num_emis_ant = 7
+
+  integer, parameter :: SEAS_OPT_DEFAULT = 1
+
+  integer, parameter :: DUST_OPT_GOCART  = 1
+  integer, parameter :: DUST_OPT_AFWA    = 3
+  integer, parameter :: DUST_OPT_FENGSHA = 5
+
+  ! -- biomass burning emissions
+  integer, parameter :: BURN_OPT_NONE   = 0
+  integer, parameter :: BURN_OPT_ENABLE = 1
+  integer, parameter :: FIRE_OPT_NONE   = 0
+  integer, parameter :: FIRE_OPT_MODIS  = 1
+  integer, parameter :: FIRE_OPT_GBBEPx = 2
+
+  ! -- hydrometeors
+  integer, parameter :: p_qv=1
+  integer, parameter :: p_qc=2
+  integer, parameter :: p_qi=3
+  ! -- set pointers to predefined atmospheric tracers
+  ! -- FV3 GFDL microphysics
+  integer, parameter :: p_atm_shum = 1
+  integer, parameter :: p_atm_cldq = 2
+  integer, parameter :: p_atm_o3mr = 7
+
+  integer :: numgas = 0
+
+
+  !integer :: num_plume_data  
+
+
+  real(kind=kind_chem) :: wetdep_ls_alpha(chem_tune_tracers)=-999.
+
+
+  !-- tracers
+  integer, parameter :: p_so2=1
+  integer, parameter :: p_sulf=2
+  integer, parameter :: p_dms=3
+  integer, parameter :: p_msa=4
+  integer, parameter :: p_p25=5
+  integer, parameter :: p_bc1=6
+  integer, parameter :: p_bc2=7
+  integer, parameter :: p_oc1=8
+  integer, parameter :: p_oc2=9
+  integer, parameter :: p_dust_1=10
+  integer, parameter :: p_dust_2=11
+  integer, parameter :: p_dust_3=12
+  integer, parameter :: p_dust_4=13
+  integer, parameter :: p_dust_5=14
+  integer, parameter :: p_seas_1=15
+  integer, parameter :: p_seas_2=16
+  integer, parameter :: p_seas_3=17
+  integer, parameter :: p_seas_4=18
+  integer, parameter :: p_seas_5=19
+  integer, parameter :: p_p10   =20
+
+  integer, parameter :: p_edust1=1,p_edust2=2,p_edust3=3,p_edust4=4,p_edust5=5
+  integer, parameter :: p_eseas1=1,p_eseas2=2,p_eseas3=3,p_eseas4=4,p_eseas5=5
+ 
+  integer :: p_ho=0,p_h2o2=0,p_no3=0
+
+  ! constants
+  real(kind=kind_chem), PARAMETER :: airmw      = 28.97
+  real(kind=kind_chem), PARAMETER :: mw_so2_aer = 64.066
+  real(kind=kind_chem), PARAMETER :: mw_so4_aer = 96.066
+  real(kind=kind_chem), parameter :: smw        = 32.00
+  real(kind=kind_chem), parameter :: mwdry      = 28.
+!  <mw>d is the molecular weight of dry air (28.966), <mw>w/<mw>d = 0.62197, and
+!  (<mw>d - <mw>w)/<mw>d = 0.37803
+!  http://atmos.nmsu.edu/education_and_outreach/encyclopedia/humidity.htm
+  !-----------------------------------------------------------------------  
+  ! tracer info
+  !-----------------------------------------------------------------------
+  ! Tracer index:
+  ! default initialization for all sulfur and carbon species is 0 (undefined)
+  !     1. DMS       = Dimethyl sulfide            = CH3SCH3  
+  !     2. SO2       = Sulfur dioxide              = SO2               
+  !     3. SO4       = Sulfate                     = SO4            
+  !     4. MSA       = Methane sulfonic acid       = CH3SO3H             
+  integer            :: ndms=1, nso2=2, nso4=3, nmsa=4
+
+  ! optical
+  integer :: nbands   = 14
+  integer :: nbandlw  = 16
+  REAL,    PARAMETER :: oc_mfac = 1.8 
+  REAL,    PARAMETER :: nh4_mfac = 1.375
+
+
+  INTEGER, PARAMETER :: cbmz_mosaic_4bin_aq = 9
+  INTEGER, PARAMETER :: cbmz_mosaic_8bin_aq = 10
+  INTEGER, PARAMETER :: radm2sorg_aq = 11
+  INTEGER, PARAMETER :: racmsorg_aq = 12
+  INTEGER, PARAMETER :: mozart_kpp = 111
+  INTEGER, PARAMETER :: mozart_mosaic_4bin_kpp = 201
+  INTEGER, PARAMETER :: mozart_mosaic_4bin_aq_kpp = 202
+  INTEGER, PARAMETER :: radm2 = 1
+  INTEGER, PARAMETER :: radm2sorg = 2
+  INTEGER, PARAMETER :: radm2sorg_aqchem = 41
+  INTEGER, PARAMETER :: cbmz = 5
+  INTEGER, PARAMETER :: cbmz_bb = 6
+  INTEGER, PARAMETER :: cbmz_bb_kpp = 120
+  INTEGER, PARAMETER :: cbmz_mosaic_kpp = 170
+  INTEGER, PARAMETER :: cbmz_mosaic_4bin = 7
+  INTEGER, PARAMETER :: cbmz_mosaic_8bin = 8
+  INTEGER, PARAMETER :: cbmz_mosaic_dms_4bin_aq = 32
+  INTEGER, PARAMETER :: cbmz_mosaic_dms_8bin_aq = 34
+  INTEGER, PARAMETER :: cbmz_mosaic_dms_4bin = 31
+  INTEGER, PARAMETER :: cbmz_mosaic_dms_8bin = 33
+  INTEGER, PARAMETER :: cbmz_cam_mam3_noaq = 501
+  INTEGER, PARAMETER :: cbmz_cam_mam3_aq = 503
+  INTEGER, PARAMETER :: cbmz_cam_mam7_noaq = 502
+  INTEGER, PARAMETER :: cbmz_cam_mam7_aq = 504
+  INTEGER, PARAMETER :: mozcart_kpp = 112
+  INTEGER, PARAMETER :: racmsoavbs_kpp = 108
+  INTEGER, PARAMETER :: cbm4_kpp = 110
+  INTEGER, PARAMETER :: gocartradm2 = 303
+  INTEGER, PARAMETER :: crimech_kpp = 600
+  INTEGER, PARAMETER :: cri_mosaic_8bin_aq_kpp = 601
+  INTEGER, PARAMETER :: cri_mosaic_4bin_aq_kpp = 611
+  INTEGER, PARAMETER :: cb05_sorg_aq_kpp = 131
+  INTEGER, PARAMETER :: cb05_sorg_vbs_aq_kpp = 132
+
+  !-- plumerise 
+  integer, parameter :: p_e_bc  =1
+  integer, parameter :: p_e_oc  =2
+  integer, parameter :: p_e_sulf=3
+  integer, parameter :: p_e_pm_25=4
+  integer, parameter :: p_e_so2=5
+  integer, parameter :: p_e_pm_10=6
+  integer, parameter :: p_e_dms=7
+  integer, parameter :: p_ebu_bc  =1
+  integer, parameter :: p_ebu_oc  =2
+  integer, parameter :: p_ebu_sulf=3
+  integer, parameter :: p_ebu_pm25=4
+  integer, parameter :: p_ebu_so2=5
+  integer, parameter :: p_ebu_pm10=6
+  integer, parameter :: p_ebu_dms=7
+  integer, parameter :: p_ebu_in_bc  =1
+  integer, parameter :: p_ebu_in_oc  =2
+  integer, parameter :: p_ebu_in_sulf=3
+  integer, parameter :: p_ebu_in_pm25=4
+  integer, parameter :: p_ebu_in_so2=5
+  integer, parameter :: p_ebu_in_pm10=6
+  integer, parameter :: p_ebu_in_dms=7
+
+
+  !-- gocartracm
+  integer, parameter :: p_ebu_no = 3
+  integer, parameter :: p_ebu_no2=4
+  integer, parameter :: p_ebu_co =5
+  integer, parameter :: p_ebu_eth=6
+  integer, parameter :: p_ebu_hc3=7
+  integer, parameter :: p_ebu_hc5=8
+  integer, parameter :: p_ebu_hc8=9
+  integer, parameter :: p_ebu_xyl=10
+  integer, parameter :: p_ebu_olt=11
+  integer, parameter :: p_ebu_oli=12
+  integer, parameter :: p_ebu_tol=13
+  integer, parameter :: p_ebu_csl=14
+  integer, parameter :: p_ebu_hcho=15
+  integer, parameter :: p_ebu_in_no = 3
+  integer, parameter :: p_ebu_in_no2=4
+  integer, parameter :: p_ebu_in_co =5
+  integer, parameter :: p_ebu_in_eth=6
+  integer, parameter :: p_ebu_in_hc3=7
+  integer, parameter :: p_ebu_in_hc5=8
+  integer, parameter :: p_ebu_in_hc8=9
+  integer, parameter :: p_ebu_in_xyl=10
+  integer, parameter :: p_ebu_in_olt=11
+  integer, parameter :: p_ebu_in_oli=12
+  integer, parameter :: p_ebu_in_tol=13
+  integer, parameter :: p_ebu_in_csl=14
+  integer, parameter :: p_ebu_in_hcho=15
+
+  INTEGER , PARAMETER :: PARAM_FIRST_SCALAR = 2
+
+  integer :: p_qr  = 1
+  integer :: p_pan = 1
+  integer :: p_o3  = 1
+  integer :: p_nh3 = 1
+
+  integer :: p_tr2 = 0
+
+  integer :: p_vash_1      = 0
+  integer :: p_vash_10     = 0
+  integer :: p_vash_2      = 0
+  integer :: p_vash_3      = 0
+  integer :: p_vash_4      = 0
+  integer :: p_vash_5      = 0
+  integer :: p_vash_6      = 0
+  integer :: p_vash_7      = 0
+  integer :: p_vash_8      = 0
+  integer :: p_vash_9      = 0
+
+  !--- optical properties
+  integer :: num_ext_coef    = 5
+  integer :: num_bscat_coef  = 3
+  integer :: num_asym_par    = 3
+  integer :: p_extcof3    = 1
+  integer :: p_extcof55   = 2
+  integer :: p_extcof106  = 3
+  integer :: p_extcof3_5  = 4
+  integer :: p_extcof8_12 = 5
+  integer :: p_bscof3     = 1
+  integer :: p_bscof55    = 2
+  integer :: p_bscof106   = 3
+  integer :: p_asympar3   = 1
+  integer :: p_asympar55  = 2
+  integer :: p_asympar106 = 3
+
+    ! -- fire options
+    !select case (plumerise_flag)
+    !  case (FIRE_OPT_NONE)
+    !    ! -- valid option
+    !  case (FIRE_OPT_MODIS)
+   integer::     num_plume_data = 8
+    !  case (FIRE_OPT_GBBEPx)
+    !    ! -- valid option
+    !    num_plume_data = 1
+    !  case default
+    !    return
+    !end select
+
+
+end module gsd_chem_config

--- a/Process_Library/gsd_chem_constants.F90
+++ b/Process_Library/gsd_chem_constants.F90
@@ -1,0 +1,15 @@
+module gsd_chem_constants
+
+  implicit none
+
+  public
+
+  integer, parameter :: kind_chem = 8
+
+  real(kind=kind_chem),parameter:: con_g      =9.80665e+0_kind_chem                !< gravity (\f$m/s^{2}\f$)
+  real(kind=kind_chem),parameter:: con_rd     =2.8705e+2_kind_chem                 !< gas constant air (\f$J/kg/K\f$)
+  real(kind=kind_chem),parameter:: con_rv     =4.6150e+2_kind_chem                 !< gas constant H2O (\f$J/kg/K\f$)
+  real(kind=kind_chem),parameter:: con_cp     =1.0046e+3_kind_chem                 !< spec heat air at p (\f$J/kg/K\f$)
+  real(kind=kind_chem),parameter:: con_cv     =7.1760e+2_kind_chem                 !< spec heat air at v (\f$J/kg/K\f$)
+
+end module gsd_chem_constants

--- a/Process_Library/plume_data_mod.F90
+++ b/Process_Library/plume_data_mod.F90
@@ -1,0 +1,52 @@
+module plume_data_mod
+
+  use gsd_chem_constants , only : kind_chem
+
+  implicit none
+
+  ! -- FRP parameters
+  integer, dimension(0:20), parameter :: &
+    catb = (/                         &
+      0,                              &
+      2, 1, 2, 1,                     & !floresta tropical 2 and 4 / extra trop fores 1,3,5
+      2, 3, 3, 3, 3,                  & !cerrado/woody savanna :6 a 9
+      4, 4, 4, 4, 4, 0, 4, 0, 0, 0, 0 & !pastagem/lavouras: 10 ...
+    /)
+
+  real(kind=kind_chem), dimension(0:4), parameter :: &
+    flaming = (/ &
+      0.00, & ! 
+      0.45, & ! % biomass burned at flaming phase : tropical forest igbp 2 and 4
+      0.45, & ! % biomass burned at flaming phase : extratropical forest igbp 1 , 3 and 5
+      0.75, & ! % biomass burned at flaming phase : cerrado/woody savanna igbp 6 to 9
+      0.00  & ! % biomass burned at flaming phase : pastagem/lavoura: igbp 10 a 17
+    /)
+
+  real(kind=kind_chem), dimension(0:20), parameter :: &
+    msize= (/  &
+      0.00021, & !0near water,1Evergreen needleleaf,2EvergreenBroadleaf,!3Deciduous Needleleaf,4Deciduous Broadleaf
+      0.00021, 0.00021, 0.00021, 0.00021, & !5Mixed forest,6Closed shrublands,7Open shrublands,8Woody savannas,9Savannas,
+      0.00023, 0.00022, 0.00022, 0.00022, 0.00029, &!  10Grassland,11Permanent wetlands,12cropland,13'Urban and Built-Up'
+      0.00029, 0.00021, 0.00026, 0.00021, 0.00026, &!14cropland/natural vegetation mosaic,15Snow and ice,16Barren or sparsely vegetated
+      0.00021, 0.00021, 0.00021, 0.00021, 0.00021, 0.00021 & !17Water,18Wooded Tundra,19Mixed Tundra,20Bare Ground Tundra
+   /)
+
+  ! -- FRP buffer indices
+  integer, parameter :: p_frp_flam_frac = 1
+  integer, parameter :: p_frp_mean      = 2
+  integer, parameter :: p_frp_std       = 3
+  integer, parameter :: p_frp_mean_size = 4
+  integer, parameter :: p_frp_std_size  = 5
+  integer, parameter :: num_frp_plume   = 5
+
+  ! -- plumerise parameters
+  integer, parameter :: tropical_forest = 1
+  integer, parameter :: boreal_forest   = 2
+  integer, parameter :: savannah        = 3
+  integer, parameter :: grassland       = 4
+  integer, parameter :: nveg_agreg      = 4
+  integer, parameter :: wind_eff        = 1
+
+  public
+
+end module plume_data_mod

--- a/Process_Library/plume_rise_mod.F90
+++ b/Process_Library/plume_rise_mod.F90
@@ -1,0 +1,327 @@
+module plume_rise_mod
+
+  use gsd_chem_constants, only : kind_chem,g => con_g, cp => con_cp, &
+                                 r_d => con_rd, r_v => con_rv 
+
+  use gsd_chem_config
+
+  use plume_data_mod,  only : nveg_agreg
+  use plume_zero_mod
+  use plume_scalar_mod
+
+  implicit none
+
+  real(kind=kind_chem), parameter :: p1000 = 100000.  ! p at 1000mb (pascals)
+
+
+  private
+
+  public :: num_frp_plume
+  public :: plumerise_driver
+
+contains
+
+  subroutine plumerise_driver (ktau,dtstep,num_chem,num_ebu,num_ebu_in,          &
+             ebu,ebu_in,                                                         &
+             mean_fct_agtf,mean_fct_agef,mean_fct_agsv,mean_fct_aggr,            &
+             firesize_agtf,firesize_agef,firesize_agsv,firesize_aggr,            &
+             chem_opt,burn_opt,t_phy,q_vap,                                      &
+             rho_phy,vvel,u_phy,v_phy,p_phy,                                     &
+             z_at_w,scale_fire_emiss,plume_frp,plumerise_flag,                   &
+             ids,ide, jds,jde, kds,kde,                                          &
+             ims,ime, jms,jme, kms,kme,                                          &
+             its,ite, jts,jte, kts,kte                                         )
+
+   IMPLICIT NONE
+
+   INTEGER,      INTENT(IN   ) :: ktau,num_chem,num_ebu,               &
+                                  num_ebu_in,plumerise_flag,           &
+                                  ids,ide, jds,jde, kds,kde,           &
+                                  ims,ime, jms,jme, kms,kme,           &
+                                  its,ite, jts,jte, kts,kte
+   REAL(kind=kind_chem), DIMENSION( ims:ime, kms:kme, jms:jme, num_ebu ),              &
+         INTENT(INOUT ) ::                                   ebu
+   REAL(kind=kind_chem), DIMENSION( ims:ime, jms:jme, num_ebu_in ),                    &
+         INTENT(INOUT ) ::                                   ebu_in
+   REAL(kind=kind_chem), DIMENSION( ims:ime, jms:jme, num_frp_plume ),                 &
+         INTENT(INOUT ) ::                                   plume_frp
+   REAL(kind=kind_chem), DIMENSION( ims:ime, jms:jme ),INTENT(IN ) ::     &
+           mean_fct_agtf,mean_fct_agef,mean_fct_agsv,mean_fct_aggr,       &
+           firesize_agtf,firesize_agef,firesize_agsv,firesize_aggr
+
+!
+!
+!
+   REAL(kind=kind_chem), DIMENSION( ims:ime , kms:kme , jms:jme ),                     &
+         INTENT(IN   ) ::                                              &
+                                                      t_phy,           &
+                 z_at_w,vvel,u_phy,v_phy,rho_phy,p_phy,q_vap
+   REAL(kind=kind_chem), INTENT(IN   ) ::                             dtstep
+
+   LOGICAL,      INTENT(IN   ) :: scale_fire_emiss
+   character (len=*), intent(in) :: chem_opt,burn_opt
+
+!
+! Local variables...
+!
+      INTEGER :: nv, i, j, k, ksub, nspecies
+
+
+!     integer, parameter :: nspecies=num_ebu
+      real(kind=kind_chem), dimension (num_ebu) :: eburn_in 
+      real(kind=kind_chem), dimension (kte,num_ebu) :: eburn_out
+      real(kind=kind_chem), dimension (kte) :: u_in ,v_in ,w_in ,theta_in ,pi_in  &
+                              ,rho_phyin ,qv_in ,zmid    &
+                              ,z_lev
+      real(kind=kind_chem), dimension(nveg_agreg) :: firesize,mean_fct
+      real(kind=kind_chem) :: sum, ffirs, rcp,ratio,zk
+!     real(kind=kind_chem),save,dimension(its:ite,jts:jte) :: ffirs
+      ffirs=0.
+      rcp=r_d/cp
+      nspecies=num_ebu
+
+      if( scale_fire_emiss ) then
+        if( chem_opt /= 'MOZCART_KPP' .and. &
+            chem_opt /= 'MOZART_KPP' .and. &
+            chem_opt /= 'MOZART_MOSAIC_4BIN_VBS0_KPP' ) then
+          print*,"Fire emission scaling only supported for MOZART_KPP, MOZCART_KPP chem chem_opts"
+          !call chem_comm_abort(msg="Fire emission scaling only supported for MOZART_KPP, MOZCART_KPP chem chem_opts")
+        endif
+      endif
+
+       if ( burn_opt == 'BIOMASSB' ) then
+         do j=jts,jte
+            do i=its,ite
+            if ( chem_opt == 'GOCARTRACM'.or.chem_opt == 'RACMSOAVBS' ) then
+!               ebu(i,kts,j,p_ebu_no)=ebu_in(i,j,p_ebu_in_no)
+!               ebu(i,kts,j,p_ebu_no2)=ebu_in(i,j,p_ebu_in_no2)
+!               ebu(i,kts,j,p_ebu_co)=ebu_in(i,j,p_ebu_in_co)
+!               ebu(i,kts,j,p_ebu_co2)=ebu_in(i,j,p_ebu_in_co2)
+!               ebu(i,kts,j,p_ebu_eth)=ebu_in(i,j,p_ebu_in_eth)
+!               ebu(i,kts,j,p_ebu_hc3)=ebu_in(i,j,p_ebu_in_hc3)
+!               ebu(i,kts,j,p_ebu_hc5)=ebu_in(i,j,p_ebu_in_hc5)
+!               ebu(i,kts,j,p_ebu_hc8)=ebu_in(i,j,p_ebu_in_hc8)
+!              ! ebu(i,kts,j,p_ebu_ete)=ebu_in(i,j,p_ebu_in_ete)
+!               ebu(i,kts,j,p_ebu_olt)=ebu_in(i,j,p_ebu_in_olt)
+!               ebu(i,kts,j,p_ebu_oli)=ebu_in(i,j,p_ebu_in_oli)
+!              ! ebu(i,kts,j,p_ebu_dien)=ebu_in(i,j,p_ebu_in_dien)
+!               ebu(i,kts,j,p_ebu_iso)=ebu_in(i,j,p_ebu_in_iso)
+!              ! ebu(i,kts,j,p_ebu_api)=ebu_in(i,j,p_ebu_in_api)
+!              ! ebu(i,kts,j,p_ebu_lim)=ebu_in(i,j,p_ebu_in_lim)
+!               ebu(i,kts,j,p_ebu_tol)=ebu_in(i,j,p_ebu_in_tol)
+!               ebu(i,kts,j,p_ebu_xyl)=ebu_in(i,j,p_ebu_in_xyl)
+!               ebu(i,kts,j,p_ebu_csl)=ebu_in(i,j,p_ebu_in_csl)
+!               ebu(i,kts,j,p_ebu_hcho)=ebu_in(i,j,p_ebu_in_hcho)
+!               ebu(i,kts,j,p_ebu_ald)=ebu_in(i,j,p_ebu_in_ald)
+!               ebu(i,kts,j,p_ebu_ket)=ebu_in(i,j,p_ebu_in_ket)
+!              ! ebu(i,kts,j,p_ebu_macr)=ebu_in(i,j,p_ebu_in_macr)
+!              !ebu(i,kts,j,p_ebu_ora1)=ebu_in(i,j,p_ebu_in_ora1)
+!               ebu(i,kts,j,p_ebu_ora2)=ebu_in(i,j,p_ebu_in_ora2)
+               endif
+               ebu(i,kts,j,p_ebu_dms)=ebu_in(i,j,p_ebu_in_dms)
+!               ebu(i,kts,j,p_ebu_sulf)=ebu_in(i,j,p_ebu_in_sulf)
+               ebu(i,kts,j,p_ebu_bc)=ebu_in(i,j,p_ebu_in_bc)
+               ebu(i,kts,j,p_ebu_oc)=ebu_in(i,j,p_ebu_in_oc)
+               ebu(i,kts,j,p_ebu_so2)=ebu_in(i,j,p_ebu_in_so2)
+               ebu(i,kts,j,p_ebu_pm25)=ebu_in(i,j,p_ebu_in_pm25)
+               ebu(i,kts,j,p_ebu_pm10)=ebu_in(i,j,p_ebu_in_pm10)
+            enddo
+         enddo
+       elseif ( burn_opt == 'BIOMASSB_MOZC' .or. &
+                burn_opt == 'BIOMASSB_MOZ' ) then
+         do j=jts,jte
+            do i=its,ite
+!               ebu(i,kts,j,p_ebu_no)=ebu_in(i,j,p_ebu_in_no)
+!               ebu(i,kts,j,p_ebu_co)=ebu_in(i,j,p_ebu_in_co)
+!               ebu(i,kts,j,p_ebu_bigalk) = ebu_in(i,j,p_ebu_in_bigalk)
+!               ebu(i,kts,j,p_ebu_bigene) = ebu_in(i,j,p_ebu_in_bigene)
+!               ebu(i,kts,j,p_ebu_c2h4) = ebu_in(i,j,p_ebu_in_c2h4)
+!               ebu(i,kts,j,p_ebu_c2h5oh) = ebu_in(i,j,p_ebu_in_c2h5oh)
+!               ebu(i,kts,j,p_ebu_c2h6) = ebu_in(i,j,p_ebu_in_c2h6)
+!               ebu(i,kts,j,p_ebu_c3h6) = ebu_in(i,j,p_ebu_in_c3h6)
+!               ebu(i,kts,j,p_ebu_c3h8) = ebu_in(i,j,p_ebu_in_c3h8)
+!               ebu(i,kts,j,p_ebu_ch2o) = ebu_in(i,j,p_ebu_in_ch2o)
+!               ebu(i,kts,j,p_ebu_ch3cho) = ebu_in(i,j,p_ebu_in_ch3cho)
+!               ebu(i,kts,j,p_ebu_ch3coch3) = ebu_in(i,j,p_ebu_in_ch3coch3)
+!               ebu(i,kts,j,p_ebu_ch3oh) = ebu_in(i,j,p_ebu_in_ch3oh)
+!               ebu(i,kts,j,p_ebu_mek) = ebu_in(i,j,p_ebu_in_mek)
+!               ebu(i,kts,j,p_ebu_so2) = ebu_in(i,j,p_ebu_in_so2)
+!               ebu(i,kts,j,p_ebu_toluene) = ebu_in(i,j,p_ebu_in_toluene)
+!               ebu(i,kts,j,p_ebu_nh3) = ebu_in(i,j,p_ebu_in_nh3)
+!               ebu(i,kts,j,p_ebu_no2)=ebu_in(i,j,p_ebu_in_no2)
+!               ebu(i,kts,j,p_ebu_open) = ebu_in(i,j,p_ebu_in_open)
+!               ebu(i,kts,j,p_ebu_c10h16) = ebu_in(i,j,p_ebu_in_c10h16)
+!               ebu(i,kts,j,p_ebu_mgly) = ebu_in(i,j,p_ebu_in_mgly)
+!               ebu(i,kts,j,p_ebu_ch3cooh) = ebu_in(i,j,p_ebu_in_ch3cooh)
+!               ebu(i,kts,j,p_ebu_cres) = ebu_in(i,j,p_ebu_in_cres)
+!               ebu(i,kts,j,p_ebu_glyald) = ebu_in(i,j,p_ebu_in_glyald)
+!               ebu(i,kts,j,p_ebu_gly)=ebu_in(i,j,p_ebu_in_gly)
+!               ebu(i,kts,j,p_ebu_acetol) = ebu_in(i,j,p_ebu_in_acetol)
+!               ebu(i,kts,j,p_ebu_isop) = ebu_in(i,j,p_ebu_in_isop)
+!               ebu(i,kts,j,p_ebu_macr) = ebu_in(i,j,p_ebu_in_macr)
+!               ebu(i,kts,j,p_ebu_mvk)=ebu_in(i,j,p_ebu_in_mvk)
+            enddo
+         enddo
+         if( burn_opt == 'BIOMASSB_MOZC' ) then
+           do j=jts,jte
+!             ebu(its:ite,kts,j,p_ebu_pm10) = ebu_in(its:ite,j,p_ebu_in_pm10)
+!             ebu(its:ite,kts,j,p_ebu_pm25) = ebu_in(its:ite,j,p_ebu_in_pm25)
+!             ebu(its:ite,kts,j,p_ebu_oc) = ebu_in(its:ite,j,p_ebu_in_oc)
+!             ebu(its:ite,kts,j,p_ebu_bc) = ebu_in(its:ite,j,p_ebu_in_bc)
+           enddo
+         endif
+       elseif ( burn_opt == 'BIOMASSB_GHG' ) then
+         do j=jts,jte
+            do i=its,ite
+!               ebu(i,kts,j,p_ebu_co)  = ebu_in(i,j,p_ebu_in_co)
+!               ebu(i,kts,j,p_ebu_co2) = ebu_in(i,j,p_ebu_in_co2)
+!               ebu(i,kts,j,p_ebu_ch4) = ebu_in(i,j,p_ebu_in_ch4)
+            enddo
+          enddo
+       endif
+!
+       do nv=1,num_ebu
+          do j=jts,jte
+            do k=kts+1,kte
+               do i=its,ite
+                 ebu(i,k,j,nv)=0.
+               enddo
+            enddo
+          enddo
+       enddo
+       
+       do j=jts,jte
+          do i=its,ite
+            select case (plumerise_flag)
+              case (FIRE_OPT_MODIS)
+                sum=mean_fct_agtf(i,j)+mean_fct_agef(i,j)+mean_fct_agsv(i,j)    &
+                        +mean_fct_aggr(i,j)
+                if(sum.lt.1.e-6)Cycle
+    !           ffirs=ffirs+1
+                sum=firesize_agtf(i,j)+firesize_agef(i,j)+firesize_agsv(i,j)    &
+                        +firesize_aggr(i,j)
+                if(sum.lt.1.e-6)Cycle
+                eburn_out=0.
+                mean_fct(1)=mean_fct_agtf(i,j)
+                mean_fct(2)=mean_fct_agef(i,j)
+                mean_fct(3)=mean_fct_agsv(i,j)
+                mean_fct(4)=mean_fct_aggr(i,j)
+                firesize(1)=firesize_agtf(i,j)
+                firesize(2)=firesize_agef(i,j)
+                firesize(3)=firesize_agsv(i,j)
+                firesize(4)=firesize_aggr(i,j)
+              case (FIRE_OPT_GBBEPx)
+                if (plume_frp(i,j,p_frp_mean) < 1.e-06) cycle
+              case default
+                ! -- no further option available
+            end select
+            do nv=1,num_ebu
+            eburn_in(nv)=ebu(i,kts,j,nv)
+            enddo
+            if( maxval( eburn_in(:) ) == 0. ) cycle
+            do k=kts,kte
+              u_in(k)=u_phy(i,k,j)
+              v_in(k)=v_phy(i,k,j)
+              w_in(k)=vvel(i,k,j)
+              qv_in(k)=q_vap(i,k,j)
+              pi_in(k)=cp*(p_phy(i,k,j)/p1000mb)**rcp
+              !zk=.5*(z_at_w(i,k+1,j)-z_at_w(i,k,j))
+              zk=.5*(z_at_w(i,k+1,j)+z_at_w(i,k,j)) !lzhang
+              zmid(k)=zk-z_at_w(i,kts,j)
+              z_lev(k)=z_at_w(i,k,j)-z_at_w(i,kts,j)
+              rho_phyin(k)=rho_phy(i,k,j)
+              theta_in(k)=t_phy(i,k,j)/pi_in(k)*cp
+            enddo
+!!$              pi_in(kte)=pi_in(kte-1)  !wig: These are no longer needed after changing definition
+!!$              u_in(kte)=u_in(kte-1)    !     of kte in chem_driver (12-Oct-2007)
+!!$              v_in(kte)=v_in(kte-1)
+!!$              w_in(kte)=w_in(kte-1)
+!!$              qv_in(kte)=qv_in(kte-1)
+!!$              zmid(kte)=z(i,kte,j)-z_at_w(i,kts,j)
+!!$              z_lev(kte)=z_at_w(i,kte,j)-z_at_w(i,kts,j)
+!!$              rho_phyin(kte)=rho_phyin(kte-1)
+!!$              theta_in(kte)=theta_in(kte-1)
+            call plumerise(kte,1,1,1,1,1,1,firesize,mean_fct  &
+                    ,nspecies,eburn_in,eburn_out &
+                    ,u_in ,v_in ,w_in ,theta_in ,pi_in  &
+                    ,rho_phyin ,qv_in ,zmid    &
+                    ,z_lev,plume_frp(i,j,:),plumerise_flag)
+
+            do nv=1,num_ebu
+              do k=kts+1,kte
+                ebu(i,k,j,nv)=eburn_out(k,nv)*(z_at_w(i,k+1,j)-z_at_w(i,k,j))
+              enddo
+            enddo
+!            print*,'hli plumerise',maxval(eburn_out),maxval(plume_frp(i,j,:))
+
+has_total_emissions : &
+            if( scale_fire_emiss ) then
+is_mozcart : &
+              if( (chem_opt == 'MOZCART_KPP' .and. &
+                   burn_opt == 'BIOMASSB_MOZC') .or. &
+                  (chem_opt == 'MOZART_KPP' .and. &
+                   burn_opt == 'BIOMASSB_MOZ') .or. &
+                  (chem_opt == 'MOZART_MOSAIC_4BIN_VBS0_KPP' .and. &
+                   burn_opt == 'BIOMASSB_MOZC') ) then
+!-------------------------------------------------------------------
+! we input total emissions instead of smoldering emissions:
+! ratio of smolderling to total
+!-------------------------------------------------------------------
+                sum = 0.
+                do k = kts,kte
+                  sum = sum + ebu(i,k,j,p_ebu_co)
+                end do
+                if( sum > 0. ) then             
+                  ratio = ebu(i,kts,j,p_ebu_co)/sum
+                else
+                  ratio = 0.
+                endif
+
+                do k = kts,kte
+!                  ebu(i,k,j,p_ebu_no) = ebu(i,k,j,p_ebu_no)*ratio
+!                  ebu(i,k,j,p_ebu_co) = ebu(i,k,j,p_ebu_co)*ratio
+!                  ebu(i,k,j,p_ebu_bigalk) = ebu(i,k,j,p_ebu_bigalk)*ratio
+!                  ebu(i,k,j,p_ebu_bigene) = ebu(i,k,j,p_ebu_bigene)*ratio
+!                  ebu(i,k,j,p_ebu_c2h4)   = ebu(i,k,j,p_ebu_c2h4)*ratio
+!                  ebu(i,k,j,p_ebu_c2h5oh) = ebu(i,k,j,p_ebu_c2h5oh)*ratio
+!                  ebu(i,k,j,p_ebu_c2h6) = ebu(i,k,j,p_ebu_c2h6)*ratio
+!                  ebu(i,k,j,p_ebu_c3h6) = ebu(i,k,j,p_ebu_c3h6)*ratio
+!                  ebu(i,k,j,p_ebu_c3h8) = ebu(i,k,j,p_ebu_c3h8)*ratio
+!                  ebu(i,k,j,p_ebu_ch2o) = ebu(i,k,j,p_ebu_ch2o)*ratio
+!                  ebu(i,k,j,p_ebu_ch3cho) = ebu(i,k,j,p_ebu_ch3cho)*ratio
+!                  ebu(i,k,j,p_ebu_ch3coch3) = ebu(i,k,j,p_ebu_ch3coch3)*ratio
+!                  ebu(i,k,j,p_ebu_ch3oh)    = ebu(i,k,j,p_ebu_ch3oh)*ratio
+!                  ebu(i,k,j,p_ebu_mek) = ebu(i,k,j,p_ebu_mek)*ratio
+!                  ebu(i,k,j,p_ebu_so2) = ebu(i,k,j,p_ebu_so2)*ratio
+!                  ebu(i,k,j,p_ebu_toluene) = ebu(i,k,j,p_ebu_toluene)*ratio
+!                  ebu(i,k,j,p_ebu_nh3) = ebu(i,k,j,p_ebu_nh3)*ratio
+!                  ebu(i,k,j,p_ebu_no2)  = ebu(i,k,j,p_ebu_no2)*ratio
+!                  ebu(i,k,j,p_ebu_open) = ebu(i,k,j,p_ebu_open)*ratio
+!                  ebu(i,k,j,p_ebu_c10h16) = ebu(i,k,j,p_ebu_c10h16)*ratio
+!                  ebu(i,k,j,p_ebu_mgly) = ebu(i,k,j,p_ebu_mgly)*ratio
+!                  ebu(i,k,j,p_ebu_ch3cooh) = ebu(i,k,j,p_ebu_ch3cooh)*ratio
+!                  ebu(i,k,j,p_ebu_cres) = ebu(i,k,j,p_ebu_cres)*ratio
+!                  ebu(i,k,j,p_ebu_glyald) = ebu(i,k,j,p_ebu_glyald)*ratio
+!                  ebu(i,k,j,p_ebu_gly) = ebu(i,k,j,p_ebu_gly)*ratio
+!                  ebu(i,k,j,p_ebu_acetol) = ebu(i,k,j,p_ebu_acetol)*ratio
+!                  ebu(i,k,j,p_ebu_isop) = ebu(i,k,j,p_ebu_isop)*ratio
+!                  ebu(i,k,j,p_ebu_macr) = ebu(i,k,j,p_ebu_macr)*ratio
+!                  ebu(i,k,j,p_ebu_mvk)  = ebu(i,k,j,p_ebu_mvk)*ratio
+                end do
+                if( chem_opt == 'MOZCART_KPP' .or. &
+                    chem_opt == 'MOZART_MOSAIC_4BIN_VBS0_KPP' ) then
+                  do k = kts,kte
+!                    ebu(i,k,j,p_ebu_pm10) = ebu(i,k,j,p_ebu_pm10)*ratio
+!                    ebu(i,k,j,p_ebu_pm25) = ebu(i,k,j,p_ebu_pm25)*ratio
+!                    ebu(i,k,j,p_ebu_oc)  = ebu(i,k,j,p_ebu_oc)*ratio
+!                    ebu(i,k,j,p_ebu_bc)  = ebu(i,k,j,p_ebu_bc)*ratio
+                  end do
+                endif
+              end if is_mozcart
+            end if has_total_emissions
+
+          enddo
+          enddo
+  end subroutine plumerise_driver
+
+end module plume_rise_mod

--- a/Process_Library/plume_scalar_mod.F90
+++ b/Process_Library/plume_scalar_mod.F90
@@ -1,0 +1,2464 @@
+module plume_scalar_mod
+
+  use gsd_chem_constants, only : kind_chem, g => con_g, cp => con_cp, &
+                                 r_d => con_rd, r_v => con_rv
+
+  use gsd_chem_config, only : FIRE_OPT_GBBEPx, FIRE_OPT_MODIS
+  use plume_data_mod,  only : num_frp_plume, p_frp_flam_frac, p_frp_mean, p_frp_std, &
+                              p_frp_mean_size, p_frp_std_size, &
+                              tropical_forest, boreal_forest, savannah, grassland,   &
+                              nveg_agreg, wind_eff
+  use plume_zero_mod
+
+  real(kind=kind_chem),parameter :: p1000mb = 100000.  ! p at 1000mb (pascals)
+  real(kind=kind_chem),parameter :: rgas=r_d
+  real(kind=kind_chem),parameter :: cpor=cp/r_d
+  real(kind=kind_chem),parameter :: p00=p1000mb
+
+  public
+
+contains
+
+subroutine plumerise(m1,m2,m3,ia,iz,ja,jz,firesize,mean_fct   &
+                    ,nspecies,eburn_in,eburn_out              &
+                    ,up,vp,wp,theta,pp,dn0,rv,zt_rams,zm_rams &
+                    ,plume_frp,plumerise_flag)
+  
+  implicit none
+
+  ! arguments
+  integer :: m1,m2,m3,ia,iz,ja,jz,nspecies,plumerise_flag
+
+  real(kind=kind_chem), dimension(nveg_agreg),    intent(in)    :: firesize,mean_fct
+  real(kind=kind_chem), dimension(nspecies),      intent(in)    :: eburn_in
+  real(kind=kind_chem), dimension(m1,nspecies),   intent(out)   :: eburn_out
+  real(kind=kind_chem), dimension(m1,m2,m3),      intent(in)    :: up,vp,wp,theta,pp,dn0,rv
+  real(kind=kind_chem), dimension(m1),            intent(in)    :: zt_rams,zm_rams
+  real(kind=kind_chem), dimension(num_frp_plume), intent(inout) :: plume_frp
+
+  ! local variables
+  integer :: i,j,k,iveg_ag,imm,ispc,ixx,k1,k2,kmt
+  integer :: iloop
+  integer :: ncall = 0 
+
+  real(kind=kind_chem)               :: burnt_area,dz_flam,rhodzi,dzi,frp
+  real(kind=kind_chem)               :: q_smold_kgm2
+  real(kind=kind_chem)               :: convert_smold_to_flam
+  real(kind=kind_chem), dimension(2) :: ztopmax
+
+  !Fator de conversao de unidades
+  !!fcu=1.      !=> kg [gas/part] /kg [ar]
+  !!fcu =1.e+12   !=> ng [gas/part] /kg [ar]
+  !!real(kind=kind_chem),parameter :: fcu =1.e+6 !=> mg [gas/part] /kg [ar] 
+  !----------------------------------------------------------------------
+  !               indexacao para o array "plume(k,i,j)" 
+  ! k 
+  ! 1   => area media (m^2) dos focos  em biomas floresta dentro do gribox i,j 
+  ! 2   => area media (m^2) dos focos  em biomas savana dentro do gribox i,j
+  ! 3   => area media (m^2) dos focos  em biomas pastagem dentro do gribox i,j
+  ! 4   => desvio padrao da area media (m^2) dos focos : floresta
+  ! 5   => desvio padrao da area media (m^2) dos focos : savana
+  ! 6   => desvio padrao da area media (m^2) dos focos : pastagem
+  ! 7 a 9 =>  sem uso
+  !10(=k_CO_smold) => parte da emissao total de CO correspondente a fase smoldering
+  !11, 12 e 13 => este array guarda a relacao entre
+  !               qCO( flaming, floresta) e a quantidade total emitida 
+  !               na fase smoldering, isto e;
+  !               qCO( flaming, floresta) =  plume(11,i,j)*plume(10,i,j)
+  !               qCO( flaming, savana  ) =  plume(12,i,j)*plume(10,i,j)
+  !               qCO( flaming, pastagem) =  plume(13,i,j)*plume(10,i,j)
+  !20(=k_PM25_smold),21,22 e 23 o mesmo para PM25               
+  !
+  !24-n1 =>  sem uso
+  !----------------------------------------------------------------------
+
+  ! initialize output
+  eburn_out = 0.
+
+  if (ncall == 0) then
+    ncall = 1
+    call zero_plumegen_coms
+  endif
+  
+    
+  j=1
+  i=1
+! do j = ja,jz           ! loop em j
+!   do i = ia,iz         ! loop em i
+     
+     !- if the max value of flaming is close to zero => there is not emission with
+     !- plume rise => cycle
+
+      do k = 1,m1
+        ucon  (k)=up(k,i,j)           ! u wind
+        vcon  (k)=vp(k,i,j)           ! v wind
+        !wcon  (k)=wp(k,i,j)           ! w wind
+        thtcon(k)=theta(k,i,j)          ! pot temperature
+        picon (k)=pp(k,i,j)                ! exner function
+        !tmpcon(k)=thtcon(k)*picon(k)/cp   ! temperature (K)
+        !dncon (k)=dn0(k,i,j)           ! dry air density (basic state)
+        !prcon (k)=(picon(k)/cp)**cpor*p00 ! pressure (Pa)
+        rvcon (k)=rv(k,i,j)            ! water vapor mixing ratio
+        zcon  (k)=zt_rams(k)               ! termod-point height
+        zzcon (k)=zm_rams(k)               ! W-point height
+      enddo
+      do ispc=1,nspecies
+        eburn_out(1,ispc) = eburn_in(ispc)
+      enddo
+
+         !- get envinronmental state (temp, water vapor mix ratio, ...)
+      call get_env_condition(1,m1,kmt,wind_eff)
+      !- loop over the four types of aggregate biomes with fires for
+      !plumerise version 1
+      !- for plumerise version 2, there is exist only one loop
+      iloop=1
+      if (plumerise_flag == FIRE_OPT_MODIS) iloop = nveg_agreg
+
+      !- loop nos 4 biomas agregados com possivel queimada
+      do iveg_ag=1,iloop
+
+        select case (plumerise_flag)
+          case (FIRE_OPT_MODIS)
+            !- verifica a existencia de emissao flaming para um bioma especifico
+            !orig: if( plume( k_CO_smold + iveg_ag ,i,j) < 1.e-6 ) cycle
+            if(mean_fct(iveg_ag) < 1.e-6 ) cycle
+ 
+            ! burnt area and standard deviation
+            burnt_area    = firesize(iveg_ag)
+
+            !-number to calculate the flaming emission from the
+            !amount emitted
+            !-during the smoldering phase
+            convert_smold_to_flam = mean_fct(iveg_ag) !FRP
+
+          case (FIRE_OPT_GBBEPx)
+            !-number to calculate the emission during the flaming pahse
+            !-from the amount emitted during the smoldering phase
+            convert_smold_to_flam=plume_frp(p_frp_flam_frac)
+
+            !- check if there is only one fire in a given grid box (=> std =0.)
+            if(plume_frp(p_frp_std) < 1.0e-6) then
+              !- if yes, we will set it as a 20% of the mean frp as a gross
+              !estimation
+              !- of the retrieval uncertainty by the sensors.
+              !- (we are not taking care about the fire size retrieval)
+              plume_frp(p_frp_std)=0.2*plume_frp(p_frp_mean)
+            endif
+          case default
+            !- no further option implemented
+        end select
+
+        !- loop nos valores  minimo e maximo da taxa de calor
+        do imm=1,2
+          if (plumerise_flag == FIRE_OPT_GBBEPx) then
+            if(imm==1 ) then
+              !for imm = 1 => lower injection height
+              burnt_area = max(1.0e4,plume_frp(p_frp_mean_size) -0.5*plume_frp(p_frp_std_size))
+              frp = max(1000.,plume_frp(p_frp_mean) - 0.5*plume_frp(p_frp_std))
+            elseif(imm==2 ) then
+              !for imm = 2 => higher injection height
+              burnt_area = max(1.0e4,plume_frp(p_frp_mean_size) +0.5*plume_frp(p_frp_std_size))
+              frp = max(1000.,plume_frp(p_frp_mean) + 0.5*plume_frp(p_frp_std))
+            endif
+          endif
+
+          !- get fire properties (burned area, plume radius, heating rates ...)
+          call get_fire_properties(imm,iveg_ag,burnt_area,frp,plumerise_flag)
+     
+          !------  generates the plume rise    ------
+
+          !-- only one value for eflux of GRASSLAND
+          if (plumerise_flag == FIRE_OPT_MODIS) then
+            if(iveg_ag == 4         .and. imm == 2) then
+              ztopmax(2)=ztopmax(1)
+              ztopmax(1)=zzcon(1)
+              cycle
+            endif
+          endif
+
+          call makeplume (kmt,ztopmax(imm),ixx,imm)
+
+        enddo ! enddo do loop em imm
+
+        !- define o dominio vertical onde a emissao flaming ira ser colocada
+        call set_flam_vert(ztopmax,k1,k2,nkp,zzcon,W_VMD,VMD)
+
+        !- espessura da camada vertical
+        !- distribui a emissao flaming entre os niveis k1 e k2
+        dzi= 1./(zzcon(k2+1)-zzcon(k1))
+        do k=k1,k2
+          !use this in case the emission src is already in mixing ratio
+          !rhodzi= 1./(dn0(k,i,j) * dz_flam)
+          !use this in case the emission src is tracer density
+
+          do ispc = 1, nspecies
+
+            !- get back the smoldering emission in kg/m2  (actually in 1e-9 kg/m2)
+
+            !use this in case the emission src is already in mixing ratio
+            !q_smold_kgm2 = (1/dzt(2) *  dn0(2,i,j)    )*   &
+            !          chem1_src_g(bburn,ispc,ng)%sc_src(2,i,j)
+
+            !use this in case the emission src is tracer density
+            !q_smold_kgm2 = ((zt_rams(2)-zt_rams(1))                 )*   &
+            !          eburn_in(ispc)
+            q_smold_kgm2 = eburn_in(ispc)
+
+            ! units = already in ppbm,  don't need "fcu" factor
+            !eburn_out(k,ispc) = eburn_out(k,ispc) +&
+            !                       mean_fct(iveg_ag)  *&
+            !                       q_smold_kgm2 * &
+            !                   dzi    !use this in case the emission src is tracer density
+            eburn_out(k,ispc)= eburn_out(k,ispc) + convert_smold_to_flam * q_smold_kgm2 * dzi
+          enddo
+
+        enddo
+
+      enddo ! enddo do loop em iveg_ag
+
+!      enddo  ! loop em i
+! enddo   ! loop em j
+
+end subroutine plumerise
+!-------------------------------------------------------------------------
+
+subroutine get_env_condition(k1,k2,kmt,wind_eff)
+
+!se module_zero_plumegen_coms
+!use rconstants
+implicit none
+integer :: k1,k2,k,kcon,klcl,kmt,nk,nkmid,i
+real(kind=kind_chem) :: znz,themax,tlll,plll,rlll,zlll,dzdd,dzlll,tlcl,plcl,dzlcl,dummy
+integer :: n_setgrid = 0 
+integer :: wind_eff
+
+
+if( n_setgrid == 0) then
+  n_setgrid = 1
+  call set_grid ! define vertical grid of plume model
+                ! zt(k) =  thermo and water levels
+                ! zm(k) =  dynamical levels 
+endif
+
+znz=zcon(k2)
+do k=nkp,1,-1
+  if(zt(k).lt.znz)go to 13
+enddo
+stop ' envir stop 12'
+13 continue
+!-srf-mb
+kmt=min(k,nkp-1)
+
+nk=k2-k1+1
+!call htint(nk, wcon,zzcon,kmt,wpe,zt)
+ call htint(nk,  ucon,zcon,kmt,upe,zt)
+ call htint(nk,  vcon,zcon,kmt,vpe,zt)
+ call htint(nk,thtcon,zcon,kmt,the  ,zt)
+ call htint(nk, rvcon,zcon,kmt,qvenv,zt)
+do k=1,kmt
+  qvenv(k)=max(qvenv(k),1e-8)
+enddo
+
+pke(1)=picon(1)
+do k=1,kmt
+  thve(k)=the(k)*(1.+.61*qvenv(k)) ! virtual pot temperature
+enddo
+do k=2,kmt
+  pke(k)=pke(k-1)-g*2.*(zt(k)-zt(k-1))  & ! exner function
+        /(thve(k)+thve(k-1))
+enddo
+do k=1,kmt
+  te(k)  = the(k)*pke(k)/cp         ! temperature (K) 
+  pe(k)  = (pke(k)/cp)**cpor*p00    ! pressure (Pa)
+  dne(k)= pe(k)/(rgas*te(k)*(1.+.61*qvenv(k))) !  dry air density (kg/m3)
+!-srf-mb
+  vel_e(k) = sqrt(upe(k)**2+vpe(k)**2)         !-env wind (m/s)
+enddo
+
+!-ewe - env wind effect
+if(wind_eff < 1)  vel_e(1:kmt) = 0.
+
+!-use este para gerar o RAMS.out
+! ------- print environment state
+!print*,'k,zt(k),pe(k),te(k)-273.15,qvenv(k)*1000'
+!do k=1,kmt
+! write(*,100)  k,zt(k),pe(k),te(k)-273.15,qvenv(k)*1000.
+! 100 format(1x,I5,4f20.12)
+!enddo
+!stop 333
+
+
+!--------- nao eh necessario este calculo
+!do k=1,kmt
+!  call thetae(pe(k),te(k),qvenv(k),thee(k))
+!enddo
+
+
+!--------- converte press de Pa para kPa para uso modelo de plumerise
+do k=1,kmt
+ pe(k) = pe(k)*1.e-3
+enddo 
+
+return 
+end subroutine get_env_condition
+
+!-------------------------------------------------------------------------
+
+subroutine set_grid()
+!use module_zero_plumegen_coms  
+implicit none
+integer :: k,mzp
+
+dz=100. ! set constant grid spacing of plume grid model(meters)
+
+mzp=nkp
+zt(1) = zsurf
+zm(1) = zsurf
+zt(2) = zt(1) + 0.5*dz
+zm(2) = zm(1) + dz
+do k=3,mzp
+ zt(k) = zt(k-1) + dz ! thermo and water levels
+ zm(k) = zm(k-1) + dz ! dynamical levels
+enddo
+do k = 1,mzp-1
+   dzm(k) = 1. / (zt(k+1) - zt(k))
+enddo 
+dzm(mzp)=dzm(mzp-1)
+
+do k = 2,mzp
+   dzt(k) = 1. / (zm(k) - zm(k-1))
+enddo
+dzt(1) = dzt(2) * dzt(2) / dzt(3)
+   
+!   dzm(1) = 0.5/dz
+!   dzm(2:mzp) = 1./dz
+return
+end subroutine set_grid
+!-------------------------------------------------------------------------
+
+  SUBROUTINE set_flam_vert(ztopmax,k1,k2,nkp,zzcon,W_VMD,VMD)
+
+    REAL(kind=kind_chem)    , INTENT(IN)  :: ztopmax(2)
+    INTEGER , INTENT(OUT) :: k1
+    INTEGER , INTENT(OUT) :: k2
+
+    ! plumegen_coms
+    INTEGER , INTENT(IN)  :: nkp
+    REAL(kind=kind_chem)    , INTENT(IN)  :: zzcon(nkp)
+
+    INTEGER imm,k
+    INTEGER, DIMENSION(2)  :: k_lim
+
+    !- version 2
+    REAL(kind=kind_chem)    , INTENT(IN)  :: W_VMD(nkp,2)
+    REAL(kind=kind_chem)    , INTENT(OUT) ::   VMD(nkp,2)
+    real(kind=kind_chem)   w_thresold,xxx
+    integer k_initial,k_final,ko,kk4,kl
+
+    !- version 1
+    DO imm=1,2
+       ! checar 
+       !    do k=1,m1-1
+       DO k=1,nkp-1
+          IF(zzcon(k) > ztopmax(imm) ) EXIT
+       ENDDO
+       k_lim(imm) = k
+    ENDDO
+    k1=MAX(3,k_lim(1))
+    k2=MAX(3,k_lim(2))
+
+    IF(k2 < k1) THEN
+       k2=k1
+       !stop 1234
+    ENDIF
+    
+    !- version 2    
+    !- vertical mass distribution
+    !- 
+    w_thresold = 1.
+    DO imm=1,2
+
+    
+       VMD(1:nkp,imm)= 0.
+       xxx=0.
+       k_initial= 0
+       k_final  = 0
+    
+       !- define range of the upper detrainemnt layer
+       do ko=nkp-10,2,-1
+     
+        if(w_vmd(ko,imm) < w_thresold) cycle
+     
+        if(k_final==0) k_final=ko
+     
+        if(w_vmd(ko,imm)-1. > w_vmd(ko-1,imm)) then
+          k_initial=ko
+          exit
+        endif
+      
+       enddo
+       !- if there is a non zero depth layer, make the mass vertical distribution 
+       if(k_final > 0 .and. k_initial > 0) then 
+       
+           k_initial=int((k_final+k_initial)*0.5)
+       
+           !- parabolic vertical distribution between k_initial and k_final
+           kk4 = k_final-k_initial+2
+           do ko=1,kk4-1
+               kl=ko+k_initial-1
+               VMD(kl,imm) = 6.* float(ko)/float(kk4)**2 * (1. - float(ko)/float(kk4))
+           enddo
+       if(sum(VMD(1:NKP,imm)) .ne. 1.) then
+            xxx= ( 1.- sum(VMD(1:NKP,imm)) )/float(k_final-k_initial+1)
+            do ko=k_initial,k_final
+              VMD(ko,imm) = VMD(ko,imm)+ xxx !- values between 0 and 1.
+            enddo
+               !pause
+           endif
+        endif !k_final > 0 .and. k_initial > 
+
+    ENDDO
+    
+  END SUBROUTINE set_flam_vert
+!-------------------------------------------------------------------------
+
+subroutine get_fire_properties(imm,iveg_ag,burnt_area,frp,plumerise_flag)
+
+implicit none
+
+! arguments
+integer, intent(in) :: imm, iveg_ag, plumerise_flag
+real(kind=kind_chem),    intent(in) :: burnt_area, frp
+
+! local variables
+integer              :: i, icount, moist
+real(kind=kind_chem)                 :: bfract, effload, heat, hinc, heat_fluxW
+real(kind=kind_chem), dimension(2,4) :: heat_flux
+
+! local parameters
+integer, parameter :: use_last = 0
+real(kind=kind_chem),    parameter :: beta = 0.88  !ref.: Paugam et al., 2015 FRP
+
+data heat_flux/  &
+!---------------------------------------------------------------------
+!  heat flux      !IGBP Land Cover        !
+! min  ! max      !Legend and            ! reference
+!    kW/m^2       !description          !
+!--------------------------------------------------------------------
+ 30.0,     80.0,   &! Tropical Forest         ! igbp 2 & 4
+ 30.0,   80.0,   &! Boreal forest           ! igbp 1 & 3
+  4.4,     23.0,   &! cerrado/woody savanna   | igbp  5 thru 9
+  3.3,      3.3    /! Grassland/cropland      ! igbp 10 thru 17
+!--------------------------------------------------------------------
+
+
+!-- fire at the surface
+!
+!area = 20.e+4   ! area of burn, m^2
+area = burnt_area! area of burn, m^2
+
+select case (plumerise_flag)
+  case (FIRE_OPT_MODIS)
+    !fluxo de calor para o bioma
+    heat_fluxW = heat_flux(imm,iveg_ag) * 1000. ! converte para W/m^2
+  case (FIRE_OPT_GBBEPx)
+    ! "beta" factor converts FRP to convective energy
+    heat_fluxW = beta*(frp/area)/0.55 ! in W/m^2
+  case default
+    ! no further option implemented
+end select
+
+mdur = 53        ! duration of burn, minutes
+bload = 10.      ! total loading, kg/m**2 
+moist = 10       ! fuel moisture, %. average fuel moisture,percent dry
+maxtime =mdur+2  ! model time, min
+!heat = 21.e6    !- joules per kg of fuel consumed                   
+!heat = 15.5e6   !joules/kg - cerrado
+heat = 19.3e6    !joules/kg - floresta em alta floresta (mt)
+!alpha = 0.1      !- entrainment constant
+alpha = 0.05      !- entrainment constant
+
+!-------------------- printout ----------------------------------------
+
+!!WRITE ( * ,  * ) ' SURFACE =', ZSURF, 'M', '  LCL =', ZBASE, 'M'  
+!
+!PRINT*,'======================================================='
+!print * , ' FIRE BOUNDARY CONDITION   :'  
+!print * , ' DURATION OF BURN, MINUTES =',MDUR  
+!print * , ' AREA OF BURN, HA          =',AREA*1.e-4
+!print * , ' HEAT FLUX, kW/m^2          =',heat_fluxW*1.e-3
+!print * , ' TOTAL LOADING, KG/M**2    =',BLOAD  
+!print * , ' FUEL MOISTURE, %          =',MOIST !average fuel moisture,percent dry
+!print * , ' MODEL TIME, MIN.          =',MAXTIME
+!
+!
+!
+! ******************** fix up inputs *********************************
+!
+                                             
+!IF (MOD (MAXTIME, 2) .NE.0) MAXTIME = MAXTIME+1  !make maxtime even
+                                                  
+MAXTIME = MAXTIME * 60  ! and put in seconds
+!
+RSURF = SQRT (AREA / 3.14159) !- entrainment surface radius (m)
+
+FMOIST   = MOIST / 100.       !- fuel moisture fraction
+!
+!
+! calculate the energy flux and water content at lboundary.
+! fills heating() on a minute basis. could ask for a file at this po
+! in the program. whatever is input has to be adjusted to a one
+! minute timescale.
+!
+                        
+  DO I = 1, ntime         !- make sure of energy release
+    HEATING (I) = 0.0001  !- avoid possible divide by 0
+  enddo  
+!                                  
+  TDUR = MDUR * 60.       !- number of seconds in the burn
+
+  bfract = 1.             !- combustion factor
+
+  EFFLOAD = BLOAD * BFRACT  !- patchy burning
+  
+!     spread the burning evenly over the interval
+!     except for the first few minutes for stability
+  ICOUNT = 1  
+!
+  if(MDUR > NTIME) STOP 'Increase time duration (ntime) in min - see file "plumerise_mod.f90"'
+
+  DO WHILE (ICOUNT.LE.MDUR)                             
+!  HEATING (ICOUNT) = HEAT * EFFLOAD / TDUR  ! W/m**2 
+!  HEATING (ICOUNT) = 80000.  * 0.55         ! W/m**2 
+
+   HEATING (ICOUNT) = heat_fluxW  * 0.55     ! W/m**2 (0.55 converte para energia convectiva)
+   ICOUNT = ICOUNT + 1  
+  ENDDO  
+!     ramp for 5 minutes
+ IF(use_last /= 1) THEN
+
+    HINC = HEATING (1) / 4.  
+    HEATING (1) = 0.1  
+    HEATING (2) = HINC  
+    HEATING (3) = 2. * HINC  
+    HEATING (4) = 3. * HINC  
+ ELSE
+    IF(imm==1) THEN
+       HINC = HEATING (1) / 4.  
+       HEATING (1) = 0.1  
+       HEATING (2) = HINC  
+       HEATING (3) = 2. * HINC  
+       HEATING (4) = 3. * HINC 
+    ELSE 
+       HINC = (HEATING (1) - heat_flux(imm-1,iveg_ag) * 1000. *0.55)/ 4.
+       HEATING (1) = heat_flux(imm-1,iveg_ag) * 1000. *0.55 + 0.1  
+       HEATING (2) = HEATING (1)+ HINC  
+       HEATING (3) = HEATING (2)+ HINC  
+       HEATING (4) = HEATING (3)+ HINC 
+    ENDIF
+ ENDIF
+
+return
+end subroutine get_fire_properties
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE MAKEPLUME ( kmt,ztopmax,ixx,imm)  
+!
+! *********************************************************************
+!
+!    EQUATION SOURCE--Kessler Met.Monograph No. 32 V.10 (K)
+!    Alan Weinstein, JAS V.27 pp 246-255. (W),
+!    Ogura and Takahashi, Monthly Weather Review V.99,pp895-911 (OT)
+!    Roger Pielke,Mesoscale Meteorological Modeling,Academic Press,1984
+!    Originally developed by: Don Latham (USFS)
+!
+!
+! ************************ VARIABLE ID ********************************
+!
+!     DT=COMPUTING TIME INCREMENT (SEC)
+!     DZ=VERTICAL INCREMENT (M)
+!     LBASE=LEVEL ,CLOUD BASE
+!
+!     CONSTANTS:
+!       G = GRAVITATIONAL ACCELERATION 9.80796 (M/SEC/SEC).
+!       R = DRY AIR GAS CONSTANT (287.04E6 JOULE/KG/DEG K)
+!       CP = SPECIFIC HT. (1004 JOULE/KG/DEG K)
+!       HEATCOND = HEAT OF CONDENSATION (2.5E6 JOULE/KG)
+!       HEATFUS = HEAT OF FUSION (3.336E5 JOULE/KG)
+!       HEATSUBL = HEAT OF SUBLIMATION (2.83396E6 JOULE/KG)
+!       EPS = RATIO OF MOL.WT. OF WATER VAPOR TO THAT OF DRY AIR (0.622)
+!       DES = DIFFERENCE BETWEEN VAPOR PRESSURE OVER WATER AND ICE (MB)
+!       TFREEZE = FREEZING TEMPERATURE (K)
+!
+!
+!     PARCEL VALUES:
+!       T = TEMPERATURE (K)
+!       TXS = TEMPERATURE EXCESS (K)
+!       QH = HYDROMETEOR WATER CONTENT (G/G DRY AIR)
+!       QHI = HYDROMETEOR ICE CONTENT (G/G DRY AIR)
+!       QC = WATER CONTENT (G/G DRY AIR)
+!       QVAP = WATER VAPOR MIXING RATIO (G/G DRY AIR)
+!       QSAT = SATURATION MIXING RATIO (G/G DRY AIR)
+!       RHO = DRY AIR DENSITY (G/M**3) MASSES = RHO*Q'S IN G/M**3
+!       ES = SATURATION VAPOR PRESSURE (kPa)
+!
+!     ENVIRONMENT VALUES:
+!       TE = TEMPERATURE (K)
+!       PE = PRESSURE (kPa)
+!       QVENV = WATER VAPOR (G/G)
+!       RHE = RELATIVE HUMIDITY FRACTION (e/esat)
+!       DNE = dry air density (kg/m^3)
+!
+!     HEAT VALUES:
+!       HEATING = HEAT OUTPUT OF FIRE (WATTS/M**2)
+!       MDUR = DURATION OF BURN, MINUTES
+!
+!       W = VERTICAL VELOCITY (M/S)
+!       RADIUS=ENTRAINMENT RADIUS (FCN OF Z)
+!    RSURF = ENTRAINMENT RADIUS AT GROUND (SIMPLE PLUME, TURNER)
+!    ALPHA = ENTRAINMENT CONSTANT
+!       MAXTIME = TERMINATION TIME (MIN)
+!
+!
+!**********************************************************************
+!**********************************************************************               
+!use module_zero_plumegen_coms 
+implicit none 
+!logical :: endspace  
+character (len=10) :: varn
+integer ::  izprint, iconv,  itime, k, kk, kkmax, deltak,ilastprint,kmt &
+           ,ixx,nrectotal,i_micro,n_sub_step
+real(kind=kind_chem) ::  vc, g,  r,  cp,  eps,  &
+         tmelt,  heatsubl,  heatfus,  heatcond, tfreeze, &
+         ztopmax, wmax, rmaxtime, es, esat, heat,dt_save !ESAT_PR,
+character (len=2) :: cixx
+! Set threshold to be the same as dz=100., the constant grid spacing of plume grid model(meters) found in set_grid()
+    REAL(kind=kind_chem) :: DELZ_THRESOLD = 100. 
+
+    INTEGER     :: imm
+
+!  real(kind=kind_chem), external:: esat_pr!
+!
+! ******************* SOME CONSTANTS **********************************
+!
+!      XNO=10.0E06 median volume diameter raindrop (K table 4)
+!      VC = 38.3/(XNO**.125) mean volume fallspeed eqn. (K)
+!
+parameter (vc = 5.107387)  
+parameter (g = 9.80796, r = 287.04, cp = 1004., eps = 0.622,  tmelt = 273.3)
+parameter (heatsubl = 2.834e6, heatfus = 3.34e5, heatcond = 2.501e6)
+parameter (tfreeze = 269.3)  
+!
+tstpf = 2.0      !- timestep factor
+viscosity = 500.!- viscosity constant (original value: 0.001)
+
+nrectotal=150
+!
+!*************** PROBLEM SETUP AND INITIAL CONDITIONS *****************
+mintime = 1  
+ztopmax = 0. 
+ztop    = 0. 
+   time = 0.  
+     dt = 1.
+   wmax = 1. 
+kkmax   = 10
+deltaK  = 20
+ilastprint=0
+L       = 1   ! L initialization
+
+!--- initialization
+CALL INITIAL(kmt)  
+
+!--- initial print fields:
+izprint  = 0          ! if = 0 => no printout
+if (izprint.ne.0) then
+ write(cixx(1:2),'(i2.2)') ixx
+ open(2, file = 'debug.'//cixx//'.dat')  
+ open(19,file='plumegen9.'//cixx//'.gra',         &
+     form='unformatted',access='direct',status='unknown',  &
+     recl=4*nrectotal)  !PC
+!     recl=1*nrectotal) !sx6 e tupay
+ call printout (izprint,nrectotal)
+ ilastprint=2
+endif
+
+! ******************* model evolution ******************************
+rmaxtime = float(maxtime)
+!
+ DO WHILE (TIME.LE.RMAXTIME)  !beginning of time loop
+
+!   do itime=1,120
+
+!-- set model top integration
+    nm1 = min(kmt, kkmax + deltak)
+
+!-- set timestep
+    !dt = (zm(2)-zm(1)) / (tstpf * wmax)
+    dt = min(5.,(zm(2)-zm(1)) / (tstpf * wmax))
+
+!-- elapsed time, sec
+    time = time+dt
+!-- elapsed time, minutes
+    mintime = 1 + int (time) / 60
+    wmax = 1.  !no zeroes allowed.
+!************************** BEGIN SPACE LOOP **************************
+
+!-- zerout all model tendencies
+    call tend0_plumerise
+
+!-- bounday conditions (k=1)
+    L=1
+    call lbound()
+
+!-- dynamics for the level k>1 
+!-- W advection 
+!   call vel_advectc_plumerise(NM1,WC,WT,DNE,DZM)
+    call vel_advectc_plumerise(NM1,WC,WT,RHO,DZM)
+  
+!-- scalars advection 1
+    call scl_advectc_plumerise('SC',NM1)
+
+!-- scalars advection 2
+    !call scl_advectc_plumerise2('SC',NM1)
+
+!-- scalars entrainment, adiabatic
+    call scl_misc(NM1)
+    
+!-- scalars dinamic entrainment
+     call  scl_dyn_entrain(NM1,nkp,wbar,w,adiabat,alpha,radius,tt,t,te,qvt,qv,qvenv,qct,qc,qht,qh,qit,qi,&
+                    vel_e,vel_p,vel_t,rad_p,rad_t)
+
+!-- gravity wave damping using Rayleigh friction layer fot T
+    call damp_grav_wave(1,nm1,deltak,dt,zt,zm,w,t,tt,qv,qh,qi,qc,te,pe,qvenv)
+
+!-- microphysics
+!   goto 101 ! bypass microphysics
+    dt_save=dt
+    n_sub_step=3
+    dt=dt/float(n_sub_step)
+
+    do i_micro=1,n_sub_step
+!-- sedim ?
+     call fallpart(NM1)
+!-- microphysics
+     do L=2,nm1-1
+        WBAR    = 0.5*(W(L)+W(L-1))
+        ES      = ESAT_PR (T(L))            !BLOB SATURATION VAPOR PRESSURE, EM KPA
+        QSAT(L) = (EPS * ES) / (PE(L) - ES)  !BLOB SATURATION LWC G/G DRY AIR
+        EST (L) = ES
+        RHO (L) = 3483.8 * PE (L) / T (L) ! AIR PARCEL DENSITY , G/M**3
+!srf18jun2005
+!    IF (W(L) .ge. 0.) DQSDZ = (QSAT(L  ) - QSAT(L-1)) / (ZT(L  ) -ZT(L-1))
+!    IF (W(L) .lt. 0.) DQSDZ = (QSAT(L+1) - QSAT(L  )) / (ZT(L+1) -ZT(L  ))
+    IF (W(L) .ge. 0.) then
+       DQSDZ = (QSAT(L+1) - QSAT(L-1)) / (ZT(L+1 )-ZT(L-1))
+    ELSE
+       DQSDZ = (QSAT(L+1) - QSAT(L-1)) / (ZT(L+1) -ZT(L-1))
+    ENDIF
+
+    call waterbal
+     enddo
+    enddo
+    dt=dt_save
+!
+!   101 continue
+!
+!-- W-viscosity for stability 
+    call visc_W(nm1,deltak,kmt)
+
+!-- update scalars
+    call update_plumerise(nm1,'S')
+    
+    call hadvance_plumerise(1,nm1,dt,WC,WT,W,mintime) 
+
+!-- Buoyancy
+    call buoyancy_plumerise(NM1, T, TE, QV, QVENV, QH, QI, QC, WT, SCR1)
+ 
+!-- Entrainment 
+    call entrainment(NM1,W,WT,RADIUS,ALPHA)
+
+!-- update W
+    call update_plumerise(nm1,'W')
+
+    call hadvance_plumerise(2,nm1,dt,WC,WT,W,mintime) 
+
+
+!-- misc
+    do k=2,nm1
+!    pe esta em kpa  - esat do rams esta em mbar = 100 Pa = 0.1 kpa
+!    es       = 0.1*esat (t(k)) !blob saturation vapor pressure, em kPa
+!    rotina do plumegen calcula em kPa
+     es       = esat_pr (t(k))  !blob saturation vapor pressure, em kPa
+     qsat(k) = (eps * es) / (pe(k) - es)  !blob saturation lwc g/g dry air
+     est (k) = es  
+     txs (k) = t(k) - te(k)
+     rho (k) = 3483.8 * pe (k) / t (k) ! air parcel density , g/m**3
+                                       ! no pressure diff with radius
+
+     if((abs(wc(k))).gt.wmax) wmax = abs(wc(k)) ! keep wmax largest w
+    enddo  
+
+! Gravity wave damping using Rayleigh friction layer for W
+    call damp_grav_wave(2,nm1,deltak,dt,zt,zm,w,t,tt,qv,qh,qi,qc,te,pe,qvenv)
+!---
+       !- update radius
+       do k=2,nm1
+        radius(k) = rad_p(k)
+       enddo
+      !-- try to find the plume top (above surface height)
+       kk = 1
+       DO WHILE (w (kk) .GT. 1.)  
+          kk = kk + 1  
+          ztop =  zm(kk) 
+       ENDDO
+       !
+       ztop_(mintime) = ztop
+       ztopmax = MAX (ztop, ztopmax) 
+       kkmax   = MAX (kk  , kkmax  ) 
+
+       !
+       ! if the solution is going to a stationary phase, exit
+       IF(mintime > 10) THEN                 
+          !   if(mintime > 20) then                     
+          !    if( abs(ztop_(mintime)-ztop_(mintime-10)) < DZ ) exit   
+          IF( ABS(ztop_(mintime)-ztop_(mintime-10)) < DELZ_THRESOLD) then 
+
+             !- determine W parameter to determine the VMD
+                 do k=2,nm1
+              W_VMD(k,imm) = w(k)
+                 enddo
+             EXIT ! finish the integration
+       ENDIF
+       ENDIF
+       IF(ztop_(mintime) < ztopmax) THEN
+           do k=2,nm1
+             W_VMD(k,imm) = wpass(k)
+           enddo
+                  EXIT ! finish the integration
+       ENDIF
+              do k=2, nm1
+                wpass(k)=w(k)
+              enddo
+
+    if(ilastprint == mintime) then
+      call printout (izprint,nrectotal)  
+      ilastprint = mintime+1
+    endif      
+                               
+
+ENDDO   !do next timestep
+
+!the last printout
+if (izprint.ne.0) then
+ call printout (izprint,nrectotal)  
+ close (2)            
+ close (19)            
+endif
+
+RETURN  
+END SUBROUTINE MAKEPLUME
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE BURN(EFLUX, WATER)  
+!
+!- calculates the energy flux and water content at lboundary
+!use module_zero_plumegen_coms                               
+!real(kind=kind_chem), parameter :: HEAT = 21.E6 !Joules/kg
+!real(kind=kind_chem), parameter :: HEAT = 15.5E6 !Joules/kg - cerrado
+real(kind=kind_chem), parameter :: HEAT = 19.3E6 !Joules/kg - floresta em Alta Floresta (MT)
+real(kind=kind_chem) :: eflux,water
+!
+! The emission factor for water is 0.5. The water produced, in kg,
+! is then  fuel mass*0.5 + (moist/100)*mass per square meter.
+! The fire burns for DT out of TDUR seconds, the total amount of
+! fuel burned is AREA*BLOAD*(DT/TDUR) kg. this amount of fuel is
+! considered to be spread over area AREA and so the mass burned per
+! unit area is BLOAD*(DT/TDUR), and the rate is BLOAD/TDUR.
+!        
+IF (TIME.GT.TDUR) THEN !is the burn over?   
+   EFLUX = 0.000001    !prevent a potential divide by zero
+   WATER = 0.  
+   RETURN  
+ELSE  
+!                                                   
+   EFLUX = HEATING (MINTIME)                          ! Watts/m**2                                                   
+!  WATER = EFLUX * (DT / HEAT) * (0.5 + FMOIST)       ! kg/m**2 
+   WATER = EFLUX * (DT / HEAT) * (0.5 + FMOIST) /0.55 ! kg/m**2 
+   WATER = WATER * 1000.                              ! g/m**2
+!
+ENDIF  
+!
+RETURN  
+END SUBROUTINE BURN
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE LBOUND ()  
+!
+! ********** BOUNDARY CONDITIONS AT ZSURF FOR PLUME AND CLOUD ********
+!
+! source of equations: J.S. Turner Buoyancy Effects in Fluids
+!                      Cambridge U.P. 1973 p.172,
+!                      G.A. Briggs Plume Rise, USAtomic Energy Commissio
+!                      TID-25075, 1969, P.28
+!
+! fundamentally a point source below ground. at surface, this produces
+! a velocity w(1) and temperature T(1) which vary with time. There is
+! also a water load which will first saturate, then remainder go into
+! QC(1).
+! EFLUX = energy flux at ground,watt/m**2 for the last DT
+!
+!use module_zero_plumegen_coms  
+implicit none
+real(kind=kind_chem), parameter :: g = 9.80796, r = 287.04, cp = 1004.6, eps = 0.622,tmelt = 273.3
+real(kind=kind_chem), parameter :: tfreeze = 269.3, pi = 3.14159, e1 = 1./3., e2 = 5./3.
+real(kind=kind_chem) :: es,  esat, eflux, water,  pres, c1,  c2, f, zv,  denscor, xwater !,ESAT_PR
+!  real(kind=kind_chem), external:: esat_pr!
+
+!            
+QH (1) = QH (2)   !soak up hydrometeors
+QI (1) = QI (2)              
+QC (1) = 0.       !no cloud here
+!
+!
+   CALL BURN (EFLUX, WATER)  
+!
+!  calculate parameters at boundary from a virtual buoyancy point source
+!
+   PRES = PE (1) * 1000.   !need pressure in N/m**2
+                              
+   C1 = 5. / (6. * ALPHA)  !alpha is entrainment constant
+
+   C2 = 0.9 * ALPHA  
+
+   F = EFLUX / (PRES * CP * PI)  
+                             
+   F = G * R * F * AREA  !buoyancy flux
+                 
+   ZV = C1 * RSURF  !virtual boundary height
+                                   
+   W (1) = C1 * ( (C2 * F) **E1) / ZV**E1  !boundary velocity
+                                         
+   DENSCOR = C1 * F / G / (C2 * F) **E1 / ZV**E2   !density correction
+
+   T (1) = TE (1) / (1. - DENSCOR)    !temperature of virtual plume at zsurf
+   
+!
+   WC(1) = W(1)
+    VEL_P(1) = 0.
+    rad_p(1) = rsurf
+
+   !SC(1) = SCE(1)+F/1000.*dt  ! gas/particle (g/g)
+
+! %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+!     match dw/dz,dt/dz at the boundary. F is conserved.
+!
+   !WBAR = W (1) * (1. - 1. / (6. * ZV) )  
+   !ADVW = WBAR * W (1) / (3. * ZV)  
+   !ADVT = WBAR * (5. / (3. * ZV) ) * (DENSCOR / (1. - DENSCOR) )  
+   !ADVC = 0.  
+   !ADVH = 0.  
+   !ADVI = 0.  
+   !ADIABAT = - WBAR * G / CP  
+   VTH (1) = - 4.  
+   VTI (1) = - 3.  
+   TXS (1) = T (1) - TE (1)  
+
+   VISC (1) = VISCOSITY  
+
+   RHO (1) = 3483.8 * PE (1) / T (1)   !air density at level 1, g/m**3
+
+   XWATER = WATER / (W (1) * DT * RHO (1) )   !firewater mixing ratio
+                                            
+   QV (1) = XWATER + QVENV (1)  !plus what's already there 
+
+
+!  PE esta em kPa  - ESAT do RAMS esta em mbar = 100 Pa = 0.1 kPa
+!  ES       = 0.1*ESAT (T(1)) !blob saturation vapor pressure, em kPa
+!  rotina do plumegen ja calcula em kPa
+   ES       = ESAT_PR (T(1))  !blob saturation vapor pressure, em kPa
+
+   EST  (1)  = ES                                  
+   QSAT (1) = (EPS * ES) / (PE (1) - ES)   !blob saturation lwc g/g dry air
+
+   IF (QV (1) .gt. QSAT (1) ) THEN
+       QC (1) = QV   (1) - QSAT (1) + QC (1)  !remainder goes into cloud drops
+       QV (1) = QSAT (1)
+   ENDIF
+!
+   CALL WATERBAL
+!
+RETURN
+END SUBROUTINE LBOUND
+!-------------------------------------------------------------------------------
+!
+SUBROUTINE INITIAL ( kmt)
+!
+! ************* SETS UP INITIAL CONDITIONS FOR THE PROBLEM ************
+!use module_zero_plumegen_coms 
+implicit none 
+real(kind=kind_chem), parameter :: tfreeze = 269.3
+integer ::  isub,  k,  n1,  n2,  n3,  lbuoy,  itmp,  isubm1 ,kmt
+real(kind=kind_chem) ::     xn1,  xi,  es,  esat!,ESAT_PR
+!
+N=kmt
+! initialize temperature structure,to the end of equal spaced sounding,
+  do k = 1, N
+  TXS (k) = 0.0
+    W (k) = 0.0
+    T (k) = TE(k)       !blob set to environment
+    WC(k) = 0.0
+    WT(k) = 0.0
+    QV(k) = QVENV (k)   !blob set to environment
+   VTH(k) = 0.        !initial rain velocity = 0
+   VTI(k) = 0.        !initial ice  velocity = 0
+    QH(k) = 0.        !no rain
+    QI(k) = 0.        !no ice
+    QC(k) = 0.        !no cloud drops
+!  PE esta em kPa  - ESAT do RAMS esta em mbar = 100 Pa = 0.1 kPa
+!  ES       = 0.1*ESAT (T(k)) !blob saturation vapor pressure, em kPa
+!  rotina do plumegen calcula em kPa
+   ES       = ESAT_PR (T(k))  !blob saturation vapor pressure, em kPa
+   EST  (k) = ES  
+   QSAT (k) = (.622 * ES) / (PE (k) - ES) !saturation lwc g/g
+   RHO  (k) = 3483.8 * PE (k) / T (k)     !dry air density g/m**3
+       VEL_P(k) = 0.
+       rad_p(k) = 0.
+  enddo  
+
+! Initialize the entrainment radius, Turner-style plume
+  radius(1) = rsurf
+  do k=2,N
+     radius(k) = radius(k-1)+(6./5.)*alpha*(zt(k)-zt(k-1))
+  enddo
+! Initialize the entrainment radius, Turner-style plume
+    radius(1) = rsurf
+    rad_p(1)  = rsurf
+    DO k=2,N
+       radius(k) = radius(k-1)+(6./5.)*alpha*(zt(k)-zt(k-1))
+       rad_p(k)  = radius(k)
+   ENDDO
+    
+!  Initialize the viscosity
+   VISC (1) = VISCOSITY
+   do k=2,N
+     !VISC (k) = VISCOSITY!max(1.e-3,visc(k-1) - 1.* VISCOSITY/float(nkp))
+     VISC (k) = max(1.e-3,visc(k-1) - 1.* VISCOSITY/float(nkp))
+   enddo
+!--   Initialize gas/concentration
+  !DO k =10,20
+  !   SC(k) = 20.
+  !ENDDO
+  !stop 333
+
+   CALL LBOUND()
+
+RETURN  
+END SUBROUTINE INITIAL
+!-------------------------------------------------------------------------------
+!
+subroutine damp_grav_wave(ifrom,nm1,deltak,dt,zt,zm,w,t,tt,qv,qh,qi,qc,te,pe,qvenv)
+implicit none
+integer nm1,ifrom,deltak
+real(kind=kind_chem) dt
+real(kind=kind_chem), dimension(nm1) :: w,t,tt,qv,qh,qi,qc,te,pe,qvenv,dummy,zt,zm
+
+if(ifrom==1) then
+ call friction(ifrom,nm1,deltak,dt,zt,zm,t,tt    ,te)
+!call friction(ifrom,nm1,dt,zt,zm,qv,qvt,qvenv)
+ return
+endif 
+
+dummy(:) = 0.
+if(ifrom==2) call friction(ifrom,nm1,deltak,dt,zt,zm,w,dummy ,dummy)
+!call friction(ifrom,nm1,dt,zt,zm,qi,qit ,dummy)
+!call friction(ifrom,nm1,dt,zt,zm,qh,qht ,dummy)
+!call friction(ifrom,nm1,dt,zt,zm,qc,qct ,dummy)
+return
+end subroutine damp_grav_wave
+!-------------------------------------------------------------------------------
+!
+subroutine friction(ifrom,nm1,deltak,dt,zt,zm,var1,vart,var2)
+implicit none
+integer k,nfpt,kf,nm1,ifrom,deltak
+real(kind=kind_chem), dimension(nm1) :: var1,var2,vart,zt,zm
+real(kind=kind_chem) zmkf,ztop,distim,c1,c2,dt
+
+!nfpt=50
+!kf = nm1 - nfpt
+!kf = nm1 - int(deltak/2)
+ kf = nm1 - int(deltak)
+
+zmkf = zm(kf) !old: float(kf )*dz
+ztop = zm(nm1)
+!distim = min(4.*dt,200.)
+!distim = 60.
+ distim = min(3.*dt,60.)
+
+c1 = 1. / (distim * (ztop - zmkf))
+c2 = dt * c1
+
+if(ifrom == 1) then  
+  do k = nm1,2,-1
+   if (zt(k) .le. zmkf) cycle
+   vart(k) = vart(k)   + c1 * (zt(k) - zmkf)*(var2(k) - var1(k))
+  enddo
+elseif(ifrom == 2) then
+  do k = nm1,2,-1
+   if (zt(k) .le. zmkf) cycle
+   var1(k) =  var1(k) + c2 * (zt(k) - zmkf)*(var2(k) - var1(k))
+  enddo
+endif
+return
+end subroutine friction
+!-------------------------------------------------------------------------------
+!
+subroutine vel_advectc_plumerise(m1,wc,wt,rho,dzm)
+
+implicit none
+integer :: k,m1
+real(kind=kind_chem), dimension(m1) :: wc,wt,flxw,dzm,rho
+real(kind=kind_chem), dimension(m1) :: dn0 ! var local
+real(kind=kind_chem) :: c1z
+
+!dzm(:)= 1./dz
+
+dn0(1:m1)=rho(1:m1)*1.e-3 ! converte de cgs para mks
+
+flxw(1) = wc(1) * dn0(1) 
+
+do k = 2,m1-1
+   flxw(k) = wc(k) * .5 * (dn0(k) + dn0(k+1))
+enddo
+
+! Compute advection contribution to W tendency
+
+c1z = .5 
+
+do k = 2,m1-2
+
+   wt(k) = wt(k)  &
+      + c1z * dzm(k) / (dn0(k) + dn0(k+1)) *     (   &
+    (flxw(k) + flxw(k-1))  * (wc(k) + wc(k-1))   &
+      - (flxw(k) + flxw(k+1))  * (wc(k) + wc(k+1))   &
+      + (flxw(k+1) - flxw(k-1)) * 2.* wc(k)       )
+
+enddo
+
+return
+end subroutine vel_advectc_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine hadvance_plumerise(iac,m1,dt,wc,wt,wp,mintime)
+
+implicit none
+integer :: k,iac
+integer :: m1,mintime
+real(kind=kind_chem), dimension(m1) :: dummy, wc,wt,wp
+real(kind=kind_chem) eps,dt
+!     It is here that the Asselin filter is applied.  For the velocities
+!     and pressure, this must be done in two stages, the first when
+!     IAC=1 and the second when IAC=2.
+
+
+eps = .2
+if(mintime == 1) eps=0.5
+
+!     For both IAC=1 and IAC=2, call PREDICT for U, V, W, and P.
+!
+call predict_plumerise(m1,wc,wp,wt,dummy,iac,2.*dt,eps)
+return
+end subroutine hadvance_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine predict_plumerise(npts,ac,ap,fa,af,iac,dtlp,epsu)
+implicit none
+integer :: npts,iac,m
+real(kind=kind_chem) :: epsu,dtlp
+real(kind=kind_chem), dimension(*) :: ac,ap,fa,af
+
+!     For IAC=3, this routine moves the arrays AC and AP forward by
+!     1 time level by adding in the prescribed tendency. It also
+!     applies the Asselin filter given by:
+
+!              {AC} = AC + EPS * (AP - 2 * AC + AF)
+
+!     where AP,AC,AF are the past, current and future time levels of A.
+!     All IAC=1 does is to perform the {AC} calculation without the AF
+!     term present.  IAC=2 completes the calculation of {AC} by adding
+!     the AF term only, and advances AC by filling it with input AP
+!     values which were already updated in ACOUSTC.
+!
+
+if (iac .eq. 1) then
+   do m = 1,npts
+      ac(m) = ac(m) + epsu * (ap(m) - 2. * ac(m))
+   enddo
+   return
+elseif (iac .eq. 2) then
+   do m = 1,npts
+      af(m) = ap(m)
+      ap(m) = ac(m) + epsu * af(m)
+   enddo
+!elseif (iac .eq. 3) then
+!   do m = 1,npts
+!      af(m) = ap(m) + dtlp * fa(m)
+!   enddo
+!   if (ngrid .eq. 1 .and. ipara .eq. 0) call cyclic(nzp,nxp,nyp,af,'T')
+!   do m = 1,npts
+!      ap(m) = ac(m) + epsu * (ap(m) - 2. * ac(m) + af(m))
+!   enddo
+endif
+
+do m = 1,npts
+  ac(m) = af(m)
+enddo
+return
+end subroutine predict_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine  buoyancy_plumerise(m1, T, TE, QV, QVENV, QH, QI, QC, WT, scr1)
+implicit none
+integer :: k,m1
+real(kind=kind_chem), parameter :: g = 9.8, eps = 0.622, gama = 0.5 ! mass virtual coeff.
+real(kind=kind_chem), dimension(m1) :: T, TE, QV, QVENV, QH, QI, QC, WT, scr1
+real(kind=kind_chem) :: TV,TVE,QWTOTL,umgamai
+real(kind=kind_chem), parameter :: mu = 0.15 
+
+!- orig
+umgamai = 1./(1.+gama) ! compensa a falta do termo de aceleracao associado `as
+                       ! das pertubacoes nao-hidrostaticas no campo de pressao
+
+!- new                 ! Siesbema et al, 2004
+!umgamai = 1./(1.-2.*mu)
+
+do k = 2,m1-1
+
+    TV =   T(k) * (1. + (QV(k)   /EPS))/(1. + QV(k)   )  !blob virtual temp.
+    TVE = TE(k) * (1. + (QVENV(k)/EPS))/(1. + QVENV(k))  !and environment
+
+    QWTOTL = QH(k) + QI(k) + QC(k)                       ! QWTOTL*G is drag
+!- orig
+   !scr1(k)= G*( umgamai*(  TV - TVE) / TVE   - QWTOTL) 
+    scr1(k)= G*  umgamai*( (TV - TVE) / TVE   - QWTOTL) 
+enddo
+
+do k = 2,m1-2
+    wt(k) = wt(k)+0.5*(scr1(k)+scr1(k+1))
+enddo
+
+end subroutine  buoyancy_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine ENTRAINMENT(m1,w,wt,radius,ALPHA)
+implicit none
+integer :: k,m1
+real(kind=kind_chem), dimension(m1) :: w,wt,radius
+REAL(kind=kind_chem) DMDTM,WBAR,RADIUS_BAR,umgamai,DYN_ENTR,ALPHA
+real(kind=kind_chem), parameter :: mu = 0.15 ,gama = 0.5 ! mass virtual coeff.
+
+!- new - Siesbema et al, 2004
+!umgamai = 1./(1.-2.*mu)
+
+!- orig
+!umgamai = 1
+umgamai = 1./(1.+gama) ! compensa a falta do termo de aceleracao associado `as
+                       ! das pertubacoes nao-hidrostaticas no campo de pressao
+
+!
+!-- ALPHA/RADIUS(L) = (1/M)DM/DZ  (W 14a)
+  do k=2,m1-1
+
+!-- for W: WBAR is only W(k)
+!     WBAR=0.5*(W(k)+W(k-1))           
+      WBAR=W(k)          
+      RADIUS_BAR = 0.5*(RADIUS(k) + RADIUS(k-1))
+! orig
+     !DMDTM =           2. * ALPHA * ABS (WBAR) / RADIUS_BAR  != (1/M)DM/DT
+      DMDTM = umgamai * 2. * ALPHA * ABS (WBAR) / RADIUS_BAR  != (1/M)DM/DT
+
+!--  DMDTM*W(L) entrainment,
+      wt(k) = wt(k)  - DMDTM*ABS (WBAR)
+      
+      !if(VEL_P (k) - VEL_E (k) > 0.) cycle
+
+       !-   dynamic entrainment
+       DYN_ENTR =  (2./3.1416)*0.5*ABS (VEL_P(k)-VEL_E(k)+VEL_P(k-1)-VEL_E(k-1)) /RADIUS_BAR
+
+       wt(k) = wt(k)  - DYN_ENTR*ABS (WBAR)
+       
+       !- entraiment acceleration for output only
+       !dwdt_entr(k) =  - DMDTM*ABS (WBAR)- DYN_ENTR*ABS (WBAR)
+  enddo
+end subroutine  ENTRAINMENT
+!-------------------------------------------------------------------------------
+!
+subroutine scl_advectc_plumerise(varn,mzp)
+!use module_zero_plumegen_coms
+implicit none
+integer :: mzp
+character(len=*) :: varn
+real(kind=kind_chem) :: dtlto2
+integer :: k
+
+!  wp => w
+!- Advect  scalars
+   dtlto2   = .5 * dt
+!  vt3dc(1) =      (w(1) + wc(1)) * dtlto2 * dne(1)
+   vt3dc(1) =      (w(1) + wc(1)) * dtlto2 * rho(1)*1.e-3!converte de CGS p/ MKS
+   vt3df(1) = .5 * (w(1) + wc(1)) * dtlto2 * dzm(1)
+
+   do k = 2,mzp
+!     vt3dc(k) =  (w(k) + wc(k)) * dtlto2 *.5 * (dne(k) + dne(k+1))
+      vt3dc(k) =  (w(k) + wc(k)) * dtlto2 *.5 * (rho(k) + rho(k+1))*1.e-3
+      vt3df(k) =  (w(k) + wc(k)) * dtlto2 *.5 *  dzm(k)
+   enddo
+
+ 
+!-srf-24082005
+!  do k = 1,mzp-1
+  do k = 1,mzp
+     vctr1(k) = (zt(k+1) - zm(k)) * dzm(k)
+     vctr2(k) = (zm(k)   - zt(k)) * dzm(k)
+!    vt3dk(k) = dzt(k) / dne(k)
+     vt3dk(k) = dzt(k) /(rho(k)*1.e-3)
+  enddo
+
+!      scalarp => scalar_tab(n,ngrid)%var_p
+!      scalart => scalar_tab(n,ngrid)%var_t
+
+!- temp advection tendency (TT)
+   scr1=T
+   call fa_zc_plumerise(mzp                   &
+                        ,T      ,scr1  (1)  &
+                        ,vt3dc (1) ,vt3df (1)  &
+                        ,vt3dg (1) ,vt3dk (1)  &
+                        ,vctr1,vctr2          )
+
+   call advtndc_plumerise(mzp,T,scr1(1),TT,dt)
+
+!- water vapor advection tendency (QVT)
+   scr1=QV
+   call fa_zc_plumerise(mzp                  &
+                        ,QV      ,scr1  (1)  &
+                        ,vt3dc (1) ,vt3df (1)  &
+                        ,vt3dg (1) ,vt3dk (1)  &
+                        ,vctr1,vctr2         )
+
+   call advtndc_plumerise(mzp,QV,scr1(1),QVT,dt)
+
+!- liquid advection tendency (QCT)
+   scr1=QC
+   call fa_zc_plumerise(mzp                  &
+                        ,QC      ,scr1  (1)  &
+                        ,vt3dc (1) ,vt3df (1)  &
+                        ,vt3dg (1) ,vt3dk (1)  &
+                        ,vctr1,vctr2         )
+
+   call advtndc_plumerise(mzp,QC,scr1(1),QCT,dt)
+
+!- ice advection tendency (QIT)
+   scr1=QI
+   call fa_zc_plumerise(mzp                  &
+                        ,QI      ,scr1  (1)  &
+                        ,vt3dc (1) ,vt3df (1)  &
+                        ,vt3dg (1) ,vt3dk (1)  &
+                        ,vctr1,vctr2         )
+
+   call advtndc_plumerise(mzp,QI,scr1(1),QIT,dt)
+
+!- hail/rain advection tendency (QHT)
+!   if(ak1 > 0. .or. ak2 > 0.) then
+
+      scr1=QH
+      call fa_zc_plumerise(mzp                  &
+                           ,QH        ,scr1  (1)  &
+                           ,vt3dc (1) ,vt3df (1)  &
+                           ,vt3dg (1) ,vt3dk (1)  &
+                           ,vctr1,vctr2           )
+
+      call advtndc_plumerise(mzp,QH,scr1(1),QHT,dt)
+!   endif
+    !- horizontal wind advection tendency (VEL_T)
+    scr1=VEL_P
+    call fa_zc_plumerise(mzp              &
+                ,VEL_P     ,scr1  (1)  &
+                ,vt3dc (1) ,vt3df (1)  &
+                ,vt3dg (1) ,vt3dk (1)  &
+                ,vctr1,vctr2         )
+
+    call advtndc_plumerise(mzp,VEL_P,scr1(1),VEL_T,dt)
+
+    !- vertical radius transport
+
+    scr1=rad_p
+    call fa_zc_plumerise(mzp                  &
+                         ,rad_p     ,scr1  (1)  &
+                         ,vt3dc (1) ,vt3df (1)  &
+                         ,vt3dg (1) ,vt3dk (1)  &
+                         ,vctr1,vctr2         )
+
+    call advtndc_plumerise(mzp,rad_p,scr1(1),rad_t,dt)
+
+
+   return
+!
+!- gas/particle advection tendency (SCT)
+!    if(varn == 'SC')return
+   scr1=SC
+   call fa_zc_plumerise(mzp            &
+                       ,SC     ,scr1  (1)  &
+                       ,vt3dc (1) ,vt3df (1)  &
+                       ,vt3dg (1) ,vt3dk (1)  &
+                       ,vctr1,vctr2         )
+   
+   call advtndc_plumerise(mzp,SC,scr1(1),SCT,dt)
+
+
+return
+end subroutine scl_advectc_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine fa_zc_plumerise(m1,scp,scr1,vt3dc,vt3df,vt3dg,vt3dk,vctr1,vctr2)
+
+implicit none
+integer :: m1,k
+real(kind=kind_chem) :: dfact
+real(kind=kind_chem), dimension(m1) :: scp,scr1,vt3dc,vt3df,vt3dg,vt3dk
+real(kind=kind_chem), dimension(m1) :: vctr1,vctr2
+
+dfact = .5
+
+! Compute scalar flux VT3DG
+      do k = 1,m1-1
+         vt3dg(k) = vt3dc(k)                   &
+                  * (vctr1(k) * scr1(k)        &
+                  +  vctr2(k) * scr1(k+1)      &
+                  +  vt3df(k) * (scr1(k) - scr1(k+1)))
+      enddo
+      
+! Modify fluxes to retain positive-definiteness on scalar quantities.
+!    If a flux will remove 1/2 quantity during a timestep,
+!    reduce to first order flux. This will remain positive-definite
+!    under the assumption that ABS(CFL(i)) + ABS(CFL(i-1)) < 1.0 if
+!    both fluxes are evacuating the box.
+
+do k = 1,m1-1
+ if (vt3dc(k) .gt. 0.) then
+   if (vt3dg(k) * vt3dk(k)    .gt. dfact * scr1(k)) then
+     vt3dg(k) = vt3dc(k) * scr1(k)
+   endif
+ elseif (vt3dc(k) .lt. 0.) then
+   if (-vt3dg(k) * vt3dk(k+1) .gt. dfact * scr1(k+1)) then
+     vt3dg(k) = vt3dc(k) * scr1(k+1)
+   endif
+ endif
+
+enddo
+
+! Compute flux divergence
+
+do k = 2,m1-1
+    scr1(k) = scr1(k)  &
+            + vt3dk(k) * ( vt3dg(k-1) - vt3dg(k) &
+            + scp  (k) * ( vt3dc(k)   - vt3dc(k-1)))
+enddo
+return
+end subroutine fa_zc_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine advtndc_plumerise(m1,scp,sca,sct,dtl)
+implicit none
+integer :: m1,k
+real(kind=kind_chem) :: dtl,dtli
+real(kind=kind_chem), dimension(m1) :: scp,sca,sct
+
+dtli = 1. / dtl
+do k = 2,m1-1
+   sct(k) = sct(k) + (sca(k)-scp(k)) * dtli
+enddo
+return
+end subroutine advtndc_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine tend0_plumerise
+!use module_zero_plumegen_coms, only: nm1,wt,tt,qvt,qct,qht,qit,sct
+ wt(1:nm1)  = 0.
+ tt(1:nm1)  = 0.
+qvt(1:nm1)  = 0.
+qct(1:nm1)  = 0.
+qht(1:nm1)  = 0.
+qit(1:nm1)  = 0.
+vel_t(1:nm1)  = 0.
+rad_t(1:nm1)  = 0.
+!sct(1:nm1)  = 0.
+end subroutine tend0_plumerise
+
+!     ****************************************************************
+
+subroutine scl_misc(m1)
+!use module_zero_plumegen_coms
+implicit none
+real(kind=kind_chem), parameter :: g = 9.81, cp=1004.
+integer m1,k
+real(kind=kind_chem) dmdtm
+
+ do k=2,m1-1
+      WBAR    = 0.5*(W(k)+W(k-1))  
+!-- dry adiabat
+      ADIABAT = - WBAR * G / CP 
+!      
+!-- entrainment     
+      DMDTM = 2. * ALPHA * ABS (WBAR) / RADIUS (k)  != (1/M)DM/DT
+      
+!-- tendency temperature = adv + adiab + entrainment
+      TT(k) = TT(K) + ADIABAT - DMDTM * ( T  (k) -    TE (k) ) 
+
+!-- tendency water vapor = adv  + entrainment
+      QVT(K) = QVT(K)         - DMDTM * ( QV (k) - QVENV (k) )
+
+      QCT(K) = QCT(K)          - DMDTM * ( QC (k)  )
+      QHT(K) = QHT(K)          - DMDTM * ( QH (k)  )
+      QIT(K) = QIT(K)          - DMDTM * ( QI (k)  )
+
+      !-- tendency horizontal speed = adv  + entrainment
+      VEL_T(K) = VEL_T(K)     - DMDTM * ( VEL_P (k) - VEL_E (k) )
+
+      !-- tendency horizontal speed = adv  + entrainment
+      rad_t(K) = rad_t(K)     + 0.5*DMDTM*(6./5.)*RADIUS (k)
+!-- tendency gas/particle = adv  + entrainment
+!      SCT(K) = SCT(K)         - DMDTM * ( SC (k) -   SCE (k) )
+
+enddo
+end subroutine scl_misc
+!     ****************************************************************
+
+  SUBROUTINE scl_dyn_entrain(m1,nkp,wbar,w,adiabat,alpha,radius,tt,t,te,qvt,qv,qvenv,qct,qc,qht,qh,qit,qi,&
+                    vel_e,vel_p,vel_t,rad_p,rad_t)
+    implicit none
+
+    INTEGER , INTENT(IN)    :: m1
+
+    ! plumegen_coms
+    INTEGER , INTENT(IN)    :: nkp
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: wbar 
+    REAL(kind=kind_chem)    , INTENT(IN)    :: w(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: adiabat 
+    REAL(kind=kind_chem)    , INTENT(IN)    :: alpha
+    REAL(kind=kind_chem)    , INTENT(IN)    :: radius(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: tt(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: t(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: te(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: qvt(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: qv(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: qvenv(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: qct(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: qc(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: qht(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: qh(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: qit(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: qi(nkp)
+
+    REAL(kind=kind_chem)    , INTENT(IN)    :: vel_e(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: vel_p(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: vel_t(nkp)
+    REAL(kind=kind_chem)    , INTENT(INOUT) :: rad_T(nkp)
+    REAL(kind=kind_chem)    , INTENT(IN)    :: rad_p(nkp)
+
+    real(kind=kind_chem), parameter :: g = 9.81, cp=1004., pi=3.1416
+
+    integer k
+    real(kind=kind_chem) dmdtm
+
+    DO k=2,m1-1
+      !      
+      !-- tendency horizontal radius from dyn entrainment
+            !rad_t(K) = rad_t(K)   +    (vel_e(k)-vel_p(k)) /pi
+             rad_t(K) = rad_t(K)   + ABS((vel_e(k)-vel_p(k)))/pi
+      
+      !-- entrainment
+            !DMDTM = (2./3.1416)  *     (VEL_E (k) - VEL_P (k)) / RADIUS (k)
+             DMDTM = (2./3.1416)  *  ABS(VEL_E (k) - VEL_P (k)) / RADIUS (k)
+      
+      !-- tendency horizontal speed  from dyn entrainment
+             VEL_T(K) = VEL_T(K)     - DMDTM * ( VEL_P (k) - VEL_E (k) )
+      
+      !     if(VEL_P (k) - VEL_E (k) > 0.) cycle
+      
+      !-- tendency temperature  from dyn entrainment
+             TT(k) = TT(K)        - DMDTM * ( T (k) - TE  (k) )
+      
+      !-- tendency water vapor  from dyn entrainment
+           QVT(K) = QVT(K)        - DMDTM * ( QV (k) - QVENV (k) )
+      
+             QCT(K) = QCT(K)        - DMDTM * ( QC (k)  )
+             QHT(K) = QHT(K)        - DMDTM * ( QH (k)  )
+             QIT(K) = QIT(K)        - DMDTM * ( QI (k)  )
+      
+      !-- tendency gas/particle  from dyn entrainment
+      !     SCT(K) = SCT(K)     - DMDTM * ( SC (k) - SCE (k) )
+    
+    ENDDO
+   END SUBROUTINE scl_dyn_entrain
+
+!     ****************************************************************
+
+subroutine visc_W(m1,deltak,kmt)
+!use module_zero_plumegen_coms
+implicit none
+integer m1,k,deltak,kmt,m2
+real(kind=kind_chem) dz1t,dz1m,dz2t,dz2m,d2wdz,d2tdz  ,d2qvdz ,d2qhdz ,d2qcdz ,d2qidz ,d2scdz, &
+ d2vel_pdz,d2rad_dz
+
+
+!srf--- 17/08/2005
+!m2=min(m1+deltak,kmt)
+m2=min(m1,kmt)
+
+!do k=2,m1-1
+do k=2,m2-1
+ DZ1T   = 0.5*(ZT(K+1)-ZT(K-1))
+ DZ2T   = VISC (k) / (DZ1T * DZ1T)  
+ DZ1M   = 0.5*(ZM(K+1)-ZM(K-1))
+ DZ2M   = VISC (k) / (DZ1M * DZ1M)  
+ D2WDZ  = (W  (k + 1) - 2 * W  (k) + W  (k - 1) ) * DZ2M  
+ D2TDZ  = (T  (k + 1) - 2 * T  (k) + T  (k - 1) ) * DZ2T  
+ D2QVDZ = (QV (k + 1) - 2 * QV (k) + QV (k - 1) ) * DZ2T  
+ D2QHDZ = (QH (k + 1) - 2 * QH (k) + QH (k - 1) ) * DZ2T 
+ D2QCDZ = (QC (k + 1) - 2 * QC (k) + QC (k - 1) ) * DZ2T  
+ D2QIDZ = (QI (k + 1) - 2 * QI (k) + QI (k - 1) ) * DZ2T  
+ !D2SCDZ = (SC (k + 1) - 2 * SC (k) + SC (k - 1) ) * DZ2T 
+ d2vel_pdz=(vel_P  (k + 1) - 2 * vel_P  (k) + vel_P  (k - 1) ) * DZ2T
+ d2rad_dz =(rad_p  (k + 1) - 2 * rad_p  (k) + rad_p  (k - 1) ) * DZ2T
+ 
+  WT(k) =   WT(k) + D2WDZ 
+  TT(k) =   TT(k) + D2TDZ                          
+ QVT(k) =  QVT(k) + D2QVDZ 
+ QCT(k) =  QCT(k) + D2QCDZ 
+ QHT(k) =  QHT(k) + D2QHDZ 
+ QIT(k) =  QIT(k) + D2QIDZ     
+ vel_t(k) =   vel_t(k) + d2vel_pdz
+ rad_t(k) =   rad_t(k) + d2rad_dz
+ !SCT(k) =  SCT(k) + D2SCDZ
+enddo  
+
+end subroutine visc_W
+
+!     ****************************************************************
+
+subroutine update_plumerise(m1,varn)
+!use module_zero_plumegen_coms
+integer m1,k
+character(len=*) :: varn
+ 
+if(varn == 'W') then
+
+ do k=2,m1-1
+   W(k) =  W(k) +  WT(k) * DT  
+ enddo
+ return
+
+else 
+do k=2,m1-1
+   T(k) =  T(k) +  TT(k) * DT  
+
+  QV(k) = QV(k) + QVT(k) * DT  
+
+  QC(k) = QC(k) + QCT(k) * DT !cloud drops travel with air 
+  QH(k) = QH(k) + QHT(k) * DT  
+  QI(k) = QI(k) + QIT(k) * DT 
+! SC(k) = SC(k) + SCT(k) * DT 
+
+!srf---18jun2005  
+  QV(k) = max(0., QV(k))
+  QC(k) = max(0., QC(k))
+  QH(k) = max(0., QH(k))
+  QI(k) = max(0., QI(k))
+  
+  VEL_P(k) =  VEL_P(k) + VEL_T(k) * DT  
+  rad_p(k) =  rad_p(k) + rad_t(k) * DT  
+! SC(k) = max(0., SC(k))
+
+ enddo
+endif
+end subroutine update_plumerise
+!-------------------------------------------------------------------------------
+!
+subroutine fallpart(m1)
+!use module_zero_plumegen_coms
+integer m1,k
+real(kind=kind_chem) vtc, dfhz,dfiz,dz1
+!srf==================================
+!   verificar se o gradiente esta correto 
+!  
+!srf==================================
+!
+!     XNO=1.E7  [m**-4] median volume diameter raindrop,Kessler
+!     VC = 38.3/(XNO**.125), median volume fallspeed eqn., Kessler
+!     for ice, see (OT18), use F0=0.75 per argument there. rho*q
+!     values are in g/m**3, velocities in m/s
+
+real(kind=kind_chem), PARAMETER :: VCONST = 5.107387, EPS = 0.622, F0 = 0.75  
+real(kind=kind_chem), PARAMETER :: G = 9.81, CP = 1004.
+!
+do k=2,m1-1
+
+   VTC = VCONST * RHO (k) **.125   ! median volume fallspeed (KTable4)
+                                
+!  hydrometeor assembly velocity calculations (K Table4)
+!  VTH(k)=-VTC*QH(k)**.125  !median volume fallspeed, water            
+   VTH (k) = - 4.        !small variation with qh
+   
+   VHREL = W (k) + VTH (k)  !relative to surrounding cloud
+ 
+!  rain ventilation coefficient for evaporation
+   CVH(k) = 1.6 + 0.57E-3 * (ABS (VHREL) ) **1.5  
+!
+!  VTI(k)=-VTC*F0*QI(k)**.125    !median volume fallspeed,ice             
+   VTI (k) = - 3.                !small variation with qi
+
+   VIREL = W (k) + VTI (k)       !relative to surrounding cloud
+!
+!  ice ventilation coefficient for sublimation
+   CVI(k) = 1.6 + 0.57E-3 * (ABS (VIREL) ) **1.5 / F0  
+!
+!
+   IF (VHREL.GE.0.0) THEN  
+    DFHZ=QH(k)*(RHO(k  )*VTH(k  )-RHO(k-1)*VTH(k-1))/RHO(k-1)
+   ELSE  
+    DFHZ=QH(k)*(RHO(k+1)*VTH(k+1)-RHO(k  )*VTH(k  ))/RHO(k)
+   ENDIF  
+   !
+   !
+   IF (VIREL.GE.0.0) THEN  
+    DFIZ=QI(k)*(RHO(k  )*VTI(k  )-RHO(k-1)*VTI(k-1))/RHO(k-1)
+   ELSE  
+    DFIZ=QI(k)*(RHO(k+1)*VTI(k+1)-RHO(k  )*VTI(k  ))/RHO(k)
+   ENDIF
+   
+   DZ1=ZM(K)-ZM(K-1)
+   
+   qht(k) = qht(k) - DFHZ / DZ1 !hydrometeors don't
+
+   qit(k) = qit(k) - DFIZ / DZ1  !nor does ice? hail, what about
+
+enddo
+end subroutine fallpart
+!-------------------------------------------------------------------------------
+!-------------------------------------------------------------------------------
+!
+subroutine printout (izprint,nrectotal)  
+!use module_zero_plumegen_coms  
+real(kind=kind_chem), parameter :: tmelt = 273.3
+integer, save :: nrec
+data nrec/0/
+integer :: ko,izprint,interval,nrectotal
+real(kind=kind_chem) :: pea, btmp,etmp,vap1,vap2,gpkc,gpkh,gpki,deficit
+interval = 1              !debug time interval,min
+
+!
+IF (IZPRINT.EQ.0) RETURN  
+
+IF(MINTIME == 1) nrec = 0
+!
+WRITE (2, 430) MINTIME, DT, TIME  
+WRITE (2, 431) ZTOP  
+WRITE (2, 380)  
+!
+! do the print
+!
+ DO 390 KO = 1, nrectotal, interval  
+                             
+   PEA = PE (KO) * 10.       !pressure is stored in decibars(kPa),print in mb;
+   BTMP = T (KO) - TMELT     !temps in Celsius
+   ETMP = T (KO) - TE (KO)   !temperature excess
+   VAP1 = QV (KO)   * 1000.  !printout in g/kg for all water,
+   VAP2 = QSAT (KO) * 1000.  !vapor (internal storage is in g/g)
+   GPKC = QC (KO)   * 1000.  !cloud water
+   GPKH = QH (KO)   * 1000.  !raindrops
+   GPKI = QI (KO)   * 1000.  !ice particles 
+   DEFICIT = VAP2 - VAP1     !vapor deficit
+!
+   WRITE (2, 400) zt(KO)/1000., PEA, W (KO), BTMP, ETMP, VAP1, &
+    VAP2, GPKC, GPKH, GPKI, VTH (KO), SC(KO)
+!
+!
+!                                    !end of printout
+   
+  390 CONTINUE
+
+   nrec=nrec+1
+   write (19,rec=nrec) (W (KO), KO=1,nrectotal)
+   nrec=nrec+1
+   write (19,rec=nrec) (T (KO), KO=1,nrectotal)
+   nrec=nrec+1
+   write (19,rec=nrec) (TE(KO), KO=1,nrectotal)
+   nrec=nrec+1
+   write (19,rec=nrec) (QV(KO)*1000., KO=1,nrectotal)
+   nrec=nrec+1
+   write (19,rec=nrec) (QC(KO)*1000., KO=1,nrectotal)
+   nrec=nrec+1
+   write (19,rec=nrec) (QH(KO)*1000., KO=1,nrectotal)
+   nrec=nrec+1
+   write (19,rec=nrec) (QI(KO)*1000., KO=1,nrectotal)
+   nrec=nrec+1
+!   write (19,rec=nrec) (SC(KO), KO=1,nrectotal)
+   write (19,rec=nrec) (QSAT(KO)*1000., KO=1,nrectotal)
+   nrec=nrec+1
+   write (19,rec=nrec) (QVENV(KO)*1000., KO=1,nrectotal)
+!
+RETURN  
+!
+! ************** FORMATS *********************************************
+!
+  380 FORMAT(/,' Z(KM) P(MB) W(MPS) T(C)  T-TE   VAP   SAT   QC    QH'// &
+'     QI    VTH(MPS) SCAL'/)
+!
+  400 FORMAT(1H , F4.1,F7.2,F7.2,F6.1,6F6.2,F7.2,1X,F6.2)  
+!
+  430 FORMAT(1H ,//I5,' MINUTES       DT= ',F6.2,' SECONDS   TIME= ' &
+        ,F8.2,' SECONDS')
+  431 FORMAT(' ZTOP= ',F10.2)  
+!
+end subroutine printout
+!
+! *********************************************************************
+SUBROUTINE WATERBAL  
+!use module_zero_plumegen_coms  
+!
+                                        
+IF (QC (L) .LE.1.0E-10) QC (L) = 0.  !DEFEAT UNDERFLOW PROBLEM
+IF (QH (L) .LE.1.0E-10) QH (L) = 0.  
+IF (QI (L) .LE.1.0E-10) QI (L) = 0.  
+!
+CALL EVAPORATE    !vapor to cloud,cloud to vapor  
+!                             
+CALL SUBLIMATE    !vapor to ice  
+!                            
+CALL GLACIATE     !rain to ice 
+                           
+CALL MELT         !ice to rain
+!         
+!if(ak1 > 0. .or. ak2 > 0.) &
+CALL CONVERT () !(auto)conversion and accretion 
+!CALL CONVERT2 () !(auto)conversion and accretion 
+!
+
+RETURN  
+END SUBROUTINE WATERBAL
+! *********************************************************************
+SUBROUTINE EVAPORATE  
+!
+!- evaporates cloud,rain and ice to saturation
+!
+!use module_zero_plumegen_coms  
+implicit none
+!
+!     XNO=10.0E06
+!     HERC = 1.93*1.E-6*XN035        !evaporation constant
+!
+real(kind=kind_chem), PARAMETER :: HERC = 5.44E-4, CP = 1.004, HEATCOND = 2.5E3  
+real(kind=kind_chem), PARAMETER :: HEATSUBL = 2834., TMELT = 273., TFREEZE = 269.3
+
+real(kind=kind_chem), PARAMETER :: FRC = HEATCOND / CP, SRC = HEATSUBL / CP
+
+real(kind=kind_chem) :: evhdt, evidt, evrate, evap, sd,    quant, dividend, divisor, devidt
+
+!
+!
+SD = QSAT (L) - QV (L)  !vapor deficit
+IF (SD.EQ.0.0)  RETURN  
+!IF (abs(SD).lt.1.e-7)  RETURN  
+
+
+EVHDT = 0.  
+EVIDT = 0.  
+!evrate =0.; evap=0.; sd=0.0; quant=0.0; dividend=0.0; divisor=0.0; devidt=0.0
+                                 
+EVRATE = ABS (WBAR * DQSDZ)   !evaporation rate (Kessler 8.32)
+EVAP = EVRATE * DT            !what we can get in DT
+                                  
+
+IF (SD.LE.0.0) THEN  !     condense. SD is negative
+
+   IF (EVAP.GE.ABS (SD) ) THEN    !we get it all
+                                  
+      QC (L) = QC  (L) - SD  !deficit,remember?
+      QV (L) = QSAT(L)       !set the vapor to saturation  
+      T  (L) = T   (L) - SD * FRC  !heat gained through condensation
+                                !per gram of dry air
+      RETURN  
+
+   ELSE  
+                                 
+      QC (L) = QC (L) + EVAP         !get what we can in DT 
+      QV (L) = QV (L) - EVAP         !remove it from the vapor
+      T  (L) = T  (L) + EVAP * FRC   !get some heat
+
+      RETURN  
+
+   ENDIF  
+!
+ELSE                                !SD is positive, need some water
+!
+! not saturated. saturate if possible. use everything in order
+! cloud, rain, ice. SD is positive
+                                         
+   IF (EVAP.LE.QC (L) ) THEN        !enough cloud to last DT
+!
+                                         
+      IF (SD.LE.EVAP) THEN          !enough time to saturate
+                                         
+         QC (L) = QC (L) - SD       !remove cloud
+         QV (L) = QSAT (L)          !saturate
+         T (L) = T (L) - SD * FRC   !cool the parcel
+         RETURN  !done
+!
+
+      ELSE   !not enough time
+                                        
+         SD = SD-EVAP               !use what there is
+         QV (L) = QV (L) + EVAP     !add vapor
+         T (L) = T (L) - EVAP * FRC !lose heat
+         QC (L) = QC (L) - EVAP     !lose cloud
+                                !go on to rain.
+      ENDIF     
+!
+   ELSE                !not enough cloud to last DT
+!      
+      IF (SD.LE.QC (L) ) THEN   !but there is enough to sat
+                                          
+         QV (L) = QSAT (L)  !use it
+         QC (L) = QC (L) - SD  
+         T  (L) = T (L) - SD * FRC  
+         RETURN  
+
+      ELSE            !not enough to sat
+         SD = SD-QC (L)  
+         QV (L) = QV (L) + QC (L)  
+         T  (L) = T (L) - QC (L) * FRC         
+         QC (L) = 0.0  !all gone
+                                          
+      ENDIF       !on to rain                           
+   ENDIF          !finished with cloud
+!
+!  but still not saturated, so try to use some rain
+!  this is tricky, because we only have time DT to evaporate. if there
+!  is enough rain, we can evaporate it for dt. ice can also sublimate
+!  at the same time. there is a compromise here.....use rain first, then
+!  ice. saturation may not be possible in one DT time.
+!  rain evaporation rate (W12),(OT25),(K Table 4). evaporate rain first
+!  sd is still positive or we wouldn't be here.
+
+
+   IF (QH (L) .LE.1.E-10) GOTO 33                                  
+
+!srf-25082005
+!  QUANT = ( QC (L)  + QV (L) - QSAT (L) ) * RHO (L)   !g/m**3
+   QUANT = ( QSAT (L)- QC (L) - QV (L)   ) * RHO (L)   !g/m**3
+!
+   EVHDT = (DT * HERC * (QUANT) * (QH (L) * RHO (L) ) **.65) / RHO (L)
+!             rain evaporation in time DT
+                                         
+   IF (EVHDT.LE.QH (L) ) THEN           !enough rain to last DT
+
+      IF (SD.LE.EVHDT) THEN          !enough time to saturate
+         QH (L) = QH (L) - SD       !remove rain
+         QV (L) = QSAT (L)          !saturate
+         T (L) = T (L) - SD * FRC      !cool the parcel
+
+     RETURN              !done
+!                       
+      ELSE                               !not enough time
+         SD = SD-EVHDT           !use what there is
+         QV (L) = QV (L) + EVHDT       !add vapor
+         T (L) = T (L) - EVHDT * FRC       !lose heat
+         QH (L) = QH (L) - EVHDT       !lose rain
+
+      ENDIF                    !go on to ice.
+!                                    
+   ELSE  !not enough rain to last DT
+!
+      IF (SD.LE.QH (L) ) THEN             !but there is enough to sat
+         QV (L) = QSAT (L)                !use it
+         QH (L) = QH (L) - SD  
+         T (L) = T (L) - SD * FRC  
+         RETURN  
+!                            
+      ELSE                              !not enough to sat
+         SD = SD-QH (L)  
+         QV (L) = QV (L) + QH (L)  
+         T (L) = T (L) - QH (L) * FRC    
+         QH (L) = 0.0                   !all gone
+                                          
+      ENDIF                             !on to ice
+!
+                                          
+   ENDIF                                !finished with rain
+!
+!
+!  now for ice
+!  equation from (OT); correction factors for units applied
+!
+   33    continue
+   IF (QI (L) .LE.1.E-10) RETURN            !no ice there
+!
+   DIVIDEND = ( (1.E6 / RHO (L) ) **0.475) * (SD / QSAT (L) &
+            - 1) * (QI (L) **0.525) * 1.13
+   DIVISOR = 7.E5 + 4.1E6 / (10. * EST (L) )  
+                                                 
+   DEVIDT = - CVI(L) * DIVIDEND / DIVISOR   !rate of change
+                                                  
+   EVIDT = DEVIDT * DT                      !what we could get
+!
+! logic here is identical to rain. could get fancy and make subroutine
+! but duplication of code is easier. God bless the screen editor.
+!
+                                         
+   IF (EVIDT.LE.QI (L) ) THEN             !enough ice to last DT
+!
+                                         
+      IF (SD.LE.EVIDT) THEN            !enough time to saturate
+         QI (L) = QI (L) - SD         !remove ice
+         QV (L) = QSAT (L)            !saturate
+         T (L) = T (L) - SD * SRC        !cool the parcel
+
+         RETURN                !done
+!
+                                          
+      ELSE                                !not enough time
+                                          
+         SD = SD-EVIDT            !use what there is
+         QV (L) = QV (L) + EVIDT        !add vapor
+          T (L) =  T (L) - EVIDT * SRC        !lose heat
+         QI (L) = QI (L) - EVIDT        !lose ice
+                                          
+      ENDIF                    !go on,unsatisfied
+!                                          
+   ELSE                                   !not enough ice to last DT
+!                                         
+      IF (SD.LE.QI (L) ) THEN             !but there is enough to sat
+                                          
+         QV (L) = QSAT (L)                !use it
+         QI (L) = QI   (L) - SD  
+          T (L) =  T   (L) - SD * SRC  
+
+         RETURN  
+!
+      ELSE                                 !not enough to sat
+         SD = SD-QI (L)  
+         QV (L) = QV (L) + QI (L)  
+         T (L) = T (L) - QI (L) * SRC             
+         QI (L) = 0.0                      !all gone
+
+      ENDIF                                !on to better things
+                                           !finished with ice
+   ENDIF  
+!                                 
+ENDIF                                      !finished with the SD decision
+!
+RETURN  
+!
+END SUBROUTINE EVAPORATE
+!
+! *********************************************************************
+SUBROUTINE CONVERT ()  
+!
+!- ACCRETION AND AUTOCONVERSION
+!
+!use module_zero_plumegen_coms  
+!
+real(kind=kind_chem),      PARAMETER ::  AK1 = 0.001    !conversion rate constant
+real(kind=kind_chem),      PARAMETER ::  AK2 = 0.0052   !collection (accretion) rate
+real(kind=kind_chem),      PARAMETER ::  TH  = 0.5      !Kessler threshold
+integer,   PARAMETER ::iconv = 1        !- Kessler conversion (=0)
+                                     
+!real(kind=kind_chem), parameter :: ANBASE =  50.!*1.e+6 !Berry-number at cloud base #/m^3(maritime)
+ real(kind=kind_chem), parameter :: ANBASE =100000.!*1.e+6 !Berry-number at cloud base #/m^3(continental)
+!real(kind=kind_chem), parameter :: BDISP = 0.366       !Berry--size dispersion (maritime)
+ real(kind=kind_chem), parameter :: BDISP = 0.146       !Berry--size dispersion (continental)
+real(kind=kind_chem), parameter :: TFREEZE = 269.3  !ice formation temperature
+!
+real(kind=kind_chem) ::   accrete, con, q, h, bc1,   bc2,  total
+
+
+IF (T (L)  .LE. TFREEZE) RETURN  !process not allowed above ice
+!
+IF (QC (L) .EQ. 0.     ) RETURN  
+
+ACCRETE = 0.
+CON = 0.
+Q = RHO (L) * QC (L)
+H = RHO (L) * QH (L)
+!
+!     selection rules
+!
+!
+IF (QH (L) .GT. 0.     ) ACCRETE = AK2 * Q * (H**.875)  !accretion, Kessler
+!
+IF (ICONV.NE.0) THEN   !select Berry or Kessler
+!
+!old   BC1 = 120.
+!old   BC2 = .0266 * ANBASE * 60.
+!old   CON = BDISP * Q * Q * Q / (BC1 * Q * BDISP + BC2)
+
+   CON = Q*Q*Q*BDISP/(60.*(5.*Q*BDISP+0.0366*ANBASE))
+!
+ELSE  
+!                             
+!   CON = AK1 * (Q - TH)   !Kessler autoconversion rate
+!      
+!   IF (CON.LT.0.0) CON = 0.0   !havent reached threshold
+ 
+   CON = max(0.,AK1 * (Q - TH)) ! versao otimizada
+!
+ENDIF  
+!
+!
+TOTAL = (CON + ACCRETE) * DT / RHO (L)  
+
+!
+IF (TOTAL.LT.QC (L) ) THEN  
+!
+   QC (L) = QC (L) - TOTAL  
+   QH (L) = QH (L) + TOTAL    !no phase change involved
+   RETURN  
+!
+ELSE  
+!              
+   QH (L) = QH (L) + QC (L)    !uses all there is
+   QC (L) = 0.0  
+!
+ENDIF  
+!
+RETURN  
+!
+END SUBROUTINE CONVERT
+!
+!**********************************************************************
+!
+SUBROUTINE CONVERT2 ()  
+!use module_zero_plumegen_coms  
+implicit none
+LOGICAL  AEROSOL
+parameter(AEROSOL=.true.)
+!
+real(kind=kind_chem), parameter :: TNULL=273.16, LAT=2.5008E6 &
+                  ,EPSI=0.622 ,DB=1. ,NB=1500. !ALPHA=0.2 
+real(kind=kind_chem) :: KA,KEINS,KZWEI,KDREI,VT
+real(kind=kind_chem) :: A,B,C,D, CON,ACCRETE,total
+
+real(kind=kind_chem) Y(6),ROH
+      
+A=0.
+B=0.
+Y(1) = T(L)
+Y(4) = W(L)
+y(2) = QC(L)
+y(3) = QH(L)
+Y(5) = RADIUS(L)
+ROH =  RHO(L)*1.e-3 ! dens (MKS) ??
+
+
+! autoconversion
+
+KA = 0.0005 
+IF( Y(1) .LT. 258.15 )THEN
+!   KEINS=0.00075
+    KEINS=0.0009 
+    KZWEI=0.0052
+    KDREI=15.39
+ELSE
+    KEINS=0.0015
+    KZWEI=0.00696
+    KDREI=11.58
+ENDIF
+      
+!   ROH=PE/RD/TE
+VT=-KDREI* (Y(3)/ROH)**0.125
+
+ 
+IF (Y(4).GT.0.0 ) THEN
+ IF (AEROSOL) THEN
+   A = 1/y(4)  *  y(2)*y(2)*1000./( 60. *( 5. + 0.0366*NB/(y(2)*1000.*DB) )  )
+ ELSE
+   IF (y(2).GT.(KA*ROH)) THEN
+   A = KEINS/y(4) *(y(2) - KA*ROH )
+   ENDIF
+ ENDIF
+ELSE
+   A = 0.0
+ENDIF
+
+! accretion
+
+IF(y(4).GT.0.0) THEN
+   B = KZWEI/(y(4) - VT) * MAX(0.,y(2)) *   &
+       MAX(0.001,ROH)**(-0.875)*(MAX(0.,y(3)))**(0.875)
+ELSE
+   B = 0.0
+ENDIF
+   
+   
+      !PSATW=610.7*EXP( 17.25 *( Y(1) - TNULL )/( Y(1)-36. ) )
+      !PSATE=610.7*EXP( 22.33 *( Y(1) - TNULL )/( Y(1)- 2. ) )
+
+      !QSATW=EPSI*PSATW/( PE-(1.-EPSI)*PSATW )
+      !QSATE=EPSI*PSATE/( PE-(1.-EPSI)*PSATE )
+      
+      !MU=2.*ALPHA/Y(5)
+
+      !C = MU*( ROH*QSATW - ROH*QVE + y(2) )
+      !D = ROH*LAT*QSATW*EPSI/Y1/Y1/RD *DYDX1
+
+      
+      !DYDX(2) = - A - B - C - D  ! d rc/dz
+      !DYDX(3) = A + B            ! d rh/dz
+ 
+ 
+      ! rc=rc+dydx(2)*dz
+      ! rh=rh+dydx(3)*dz
+ 
+CON      = A
+ACCRETE  = B
+ 
+TOTAL = (CON + ACCRETE) *(1/DZM(L)) /ROH     ! DT / RHO (L)  
+
+!
+IF (TOTAL.LT.QC (L) ) THEN  
+!
+   QC (L) = QC (L) - TOTAL  
+   QH (L) = QH (L) + TOTAL    !no phase change involved
+   RETURN  
+!
+ELSE  
+!              
+   QH (L) = QH (L) + QC (L)    !uses all there is
+   QC (L) = 0.0  
+!
+ENDIF  
+!
+RETURN  
+!
+END SUBROUTINE CONVERT2
+! ice - effect on temperature
+!      TTD = 0.0 
+!      TTE = 0.0  
+!       CALL ICE(QSATW,QSATE,Y(1),Y(2),Y(3), &
+!               TTA,TTB,TTC,DZ,ROH,D,C,TTD,TTE)
+!       DYDX(1) = DYDX(1) + TTD  + TTE ! DT/DZ on Temp
+!
+!**********************************************************************
+!
+SUBROUTINE SUBLIMATE  
+!
+! ********************* VAPOR TO ICE (USE EQUATION OT22)***************
+!use module_zero_plumegen_coms  
+!
+real(kind=kind_chem), PARAMETER :: EPS = 0.622, HEATFUS = 334., HEATSUBL = 2834., CP = 1.004
+real(kind=kind_chem), PARAMETER :: SRC = HEATSUBL / CP, FRC = HEATFUS / CP, TMELT = 273.3
+real(kind=kind_chem), PARAMETER :: TFREEZE = 269.3
+
+real(kind=kind_chem) ::dtsubh,  dividend,divisor, subl
+!
+DTSUBH = 0.  
+!
+!selection criteria for sublimation
+IF (T (L)  .GT. TFREEZE  ) RETURN  
+IF (QV (L) .LE. QSAT (L) ) RETURN  
+!
+!     from (OT); correction factors for units applied
+!
+ DIVIDEND = ( (1.E6 / RHO (L) ) **0.475) * (QV (L) / QSAT (L) &
+            - 1) * (QI (L) **0.525) * 1.13
+ DIVISOR = 7.E5 + 4.1E6 / (10. * EST (L) )  
+!
+                                         
+ DTSUBH = ABS (DIVIDEND / DIVISOR)   !sublimation rate
+ SUBL = DTSUBH * DT                  !and amount possible
+!
+!     again check the possibilities
+!
+IF (SUBL.LT.QV (L) ) THEN  
+!
+   QV (L) = QV (L) - SUBL             !lose vapor
+   QI (L) = QI (L) + SUBL            !gain ice
+   T (L) = T (L) + SUBL * SRC         !energy change, warms air
+
+   RETURN  
+!
+ELSE  
+!                                     
+   QI (L) = QV (L)                    !use what there is
+   T  (L) = T (L) + QV (L) * SRC      !warm the air
+   QV (L) = 0.0  
+!
+ENDIF  
+!
+RETURN  
+END SUBROUTINE SUBLIMATE
+!
+! *********************************************************************
+!
+SUBROUTINE GLACIATE  
+!
+! *********************** CONVERSION OF RAIN TO ICE *******************
+!     uses equation OT 16, simplest. correction from W not applied, but
+!     vapor pressure differences are supplied.
+!
+!use module_zero_plumegen_coms  
+!
+real(kind=kind_chem), PARAMETER :: HEATFUS = 334., CP = 1.004, EPS = 0.622, HEATSUBL = 2834.
+real(kind=kind_chem), PARAMETER :: FRC = HEATFUS / CP, FRS = HEATSUBL / CP, TFREEZE =  269.3
+real(kind=kind_chem), PARAMETER :: GLCONST = 0.025   !glaciation time constant, 1/sec
+real(kind=kind_chem) dfrzh
+!
+                                    
+ DFRZH = 0.    !rate of mass gain in ice
+!
+!selection rules for glaciation
+IF (QH (L) .LE. 0.       ) RETURN  
+IF (QV (L) .LT. QSAT (L) ) RETURN                                        
+IF (T  (L) .GT. TFREEZE  ) RETURN  
+!
+!      NT=TMELT-T(L)
+!      IF (NT.GT.50) NT=50
+!
+                                    
+ DFRZH = DT * GLCONST * QH (L)    ! from OT(16)
+!
+IF (DFRZH.LT.QH (L) ) THEN  
+!
+   QI (L) = QI (L) + DFRZH  
+   QH (L) = QH (L) - DFRZH  
+   T (L) = T (L) + FRC * DFRZH  !warms air
+   
+   RETURN  
+!
+ELSE  
+!
+   QI (L) = QI (L) + QH (L)  
+   T  (L) = T  (L) + FRC * QH (L)  
+   QH (L) = 0.0  
+!
+ENDIF  
+!
+RETURN  
+!
+END SUBROUTINE GLACIATE
+!
+!
+! *********************************************************************
+SUBROUTINE MELT  
+!
+! ******************* MAKES WATER OUT OF ICE **************************
+!use module_zero_plumegen_coms  
+!                                              
+real(kind=kind_chem), PARAMETER :: FRC = 332.27, TMELT = 273., F0 = 0.75   !ice velocity factor
+real(kind=kind_chem) DTMELT
+!                                    
+ DTMELT = 0.   !conversion,ice to rain
+!
+!selection rules
+IF (QI (L) .LE. 0.0  ) RETURN  
+IF (T (L)  .LT. TMELT) RETURN  
+!
+                                                      !OT(23,24)
+ DTMELT = DT * (2.27 / RHO (L) ) * CVI(L) * (T (L) - TMELT) * ( (RHO(L)  &
+         * QI (L) * 1.E-6) **0.525) * (F0** ( - 0.42) )
+                                                      !after Mason,1956
+!
+!     check the possibilities
+!
+IF (DTMELT.LT.QI (L) ) THEN  
+!
+   QH (L) = QH (L) + DTMELT  
+   QI (L) = QI (L) - DTMELT  
+   T  (L) = T (L) - FRC * DTMELT     !cools air
+   
+   RETURN  
+!
+ELSE  
+!
+   QH (L) = QH (L) + QI (L)   !get all there is to get
+   T  (L) = T (L) - FRC * QI (L)  
+   QI (L) = 0.0  
+!
+ENDIF  
+!
+RETURN  
+!
+END SUBROUTINE MELT
+
+SUBROUTINE htint (nzz1, vctra, eleva, nzz2, vctrb, elevb)
+  IMPLICIT NONE
+  INTEGER, INTENT(IN ) :: nzz1
+  INTEGER, INTENT(IN ) :: nzz2
+  REAL(kind=kind_chem),    INTENT(IN ) :: vctra(nzz1)
+  REAL(kind=kind_chem),    INTENT(OUT) :: vctrb(nzz2)
+  REAL(kind=kind_chem),    INTENT(IN ) :: eleva(nzz1)
+  REAL(kind=kind_chem),    INTENT(IN ) :: elevb(nzz2)
+
+  INTEGER :: l
+  INTEGER :: k
+  INTEGER :: kk
+  REAL(kind=kind_chem)    :: wt
+
+  l=1
+
+  DO k=1,nzz2
+     DO
+        IF ( (elevb(k) <  eleva(1)) .OR. &
+             ((elevb(k) >= eleva(l)) .AND. (elevb(k) <= eleva(l+1))) ) THEN
+           wt       = (elevb(k)-eleva(l))/(eleva(l+1)-eleva(l))
+           vctrb(k) = vctra(l)+(vctra(l+1)-vctra(l))*wt
+           EXIT
+        ELSE IF ( elevb(k) >  eleva(nzz1))  THEN
+           wt       = (elevb(k)-eleva(nzz1))/(eleva(nzz1-1)-eleva(nzz1))
+           vctrb(k) = vctra(nzz1)+(vctra(nzz1-1)-vctra(nzz1))*wt
+           EXIT
+        END IF
+
+        l=l+1
+        IF(l == nzz1) THEN
+           PRINT *,'htint:nzz1',nzz1
+           DO kk=1,l
+              PRINT*,'kk,eleva(kk),elevb(kk)',eleva(kk),elevb(kk)
+           END DO
+           STOP 'htint'
+        END IF
+     END DO
+  END DO
+END SUBROUTINE htint
+!-----------------------------------------------------------------------------
+FUNCTION ESAT_PR (TEM)  
+!
+! ******* Vapor Pressure  A.L. Buck JAM V.20 p.1527. (1981) ***********
+!
+real(kind=kind_chem), PARAMETER :: CI1 = 6.1115, CI2 = 22.542, CI3 = 273.48
+real(kind=kind_chem), PARAMETER :: CW1 = 6.1121, CW2 = 18.729, CW3 = 257.87, CW4 = 227.3
+real(kind=kind_chem), PARAMETER :: TMELT = 273.3
+
+real(kind=kind_chem) ESAT_PR
+real(kind=kind_chem) temc , tem,esatm
+!
+!     formulae from Buck, A.L., JAM 20,1527-1532
+!     custom takes esat wrt water always. formula for h2o only
+!     good to -40C so:
+!
+!
+TEMC = TEM - TMELT  
+IF (TEMC.GT. - 40.0) GOTO 230  
+ESATM = CI1 * EXP (CI2 * TEMC / (TEMC + CI3) )  !ice, millibars  
+ESAT_PR = ESATM / 10.    !kPa
+
+RETURN
+!
+230 ESATM = CW1 * EXP ( ( (CW2 - (TEMC / CW4) ) * TEMC) / (TEMC + CW3))
+
+ESAT_PR = ESATM / 10.    !kPa
+RETURN
+END function ESAT_PR
+!     ******************************************************************
+
+!      ------------------------------------------------------------------------
+end module plume_scalar_mod

--- a/Process_Library/plume_zero_mod.F90
+++ b/Process_Library/plume_zero_mod.F90
@@ -1,0 +1,81 @@
+module plume_zero_mod
+
+use gsd_chem_constants, only : kind_chem
+
+implicit none
+integer, parameter :: nkp = 200, ntime = 200
+!
+real(kind=kind_chem),dimension(nkp) ::  w,t,qv,qc,qh,qi,sc,  &  ! blob
+                        vth,vti,rho,txs,  &
+                        est,qsat,qpas,qtotal
+
+real(kind=kind_chem),dimension(nkp) ::  wc,wt,tt,qvt,qct,qht,qit,sct,wpass !lzhang
+real(kind=kind_chem),dimension(nkp) ::  dzm,dzt,zm,zt,vctr1,vctr2 &
+                       ,vt3dc,vt3df,vt3dk,vt3dg,scr1
+
+!
+real(kind=kind_chem),dimension(nkp) ::  pke,the,thve,thee,pe,te,qvenv,rhe,dne,sce ! environment at plume grid
+real(kind=kind_chem),dimension(nkp) ::  ucon,vcon,wcon,thtcon ,rvcon,picon,tmpcon,dncon,prcon &
+                       ,zcon,zzcon,scon ! environment at RAMS  grid
+
+!
+real(kind=kind_chem) :: DZ,DQSDZ,VISC(nkp),VISCOSITY,TSTPF   
+integer :: N,NM1,L
+!
+real(kind=kind_chem) :: ADVW,ADVT,ADVV,ADVC,ADVH,ADVI,CVH(nkp),CVI(nkp),ADIABAT,&
+        WBAR,ALAST(10),VHREL,VIREL  ! advection
+!
+real(kind=kind_chem) :: ZSURF,ZBASE,ZTOP
+integer :: LBASE
+!
+real(kind=kind_chem) :: AREA,RSURF,ALPHA,RADIUS(nkp)  ! entrain
+!
+real(kind=kind_chem) :: HEATING(ntime),FMOIST,BLOAD   ! heating
+!
+real(kind=kind_chem) :: DT,TIME,TDUR
+integer :: MINTIME,MDUR,MAXTIME
+!
+REAL(kind=kind_chem),    DIMENSION(nkp,2)    :: W_VMD,VMD
+REAL(kind=kind_chem) :: upe   (nkp)
+REAL(kind=kind_chem) :: vpe   (nkp)
+REAL(kind=kind_chem) :: vel_e (nkp)
+
+REAL(kind=kind_chem) :: vel_p (nkp)
+REAL(kind=kind_chem) :: rad_p (nkp)
+REAL(kind=kind_chem) :: vel_t (nkp)
+REAL(kind=kind_chem) :: rad_t (nkp)
+
+real(kind=kind_chem) :: ztop_(ntime)
+
+public
+
+contains
+subroutine zero_plumegen_coms
+
+w=0.0;t=0.0;qv=0.0;qc=0.0;qh=0.0;qi=0.0;sc=0.0
+vth=0.0;vti=0.0;rho=0.0;txs=0.0
+est=0.0;qsat=0.0;qpas=0.0;qtotal=0.0
+wc=0.0;wt=0.0;wpass=0.0;tt=0.0;qvt=0.0;qct=0.0;qht=0.0;qit=0.0;sct=0.0
+dzm=0.0;dzt=0.0;zm=0.0;zt=0.0;vctr1=0.0;vctr2=0.0
+vt3dc=0.0;vt3df=0.0;vt3dk=0.0;vt3dg=0.0;scr1=0.0
+pke=0.0;the=0.0;thve=0.0;thee=0.0;pe=0.0;te=0.0;qvenv=0.0;rhe=0.0;dne=0.0;sce=0.0 
+ucon=0.0;vcon=0.0;wcon=0.0;thtcon =0.0;rvcon=0.0;picon=0.0;tmpcon=0.0;dncon=0.0;prcon=0.0 
+zcon=0.0;zzcon=0.0;scon=0.0 
+dz=0.0;dqsdz=0.0;visc=0.0;viscosity=0.0;tstpf=0.0
+advw=0.0;advt=0.0;advv=0.0;advc=0.0;advh=0.0;advi=0.0;cvh=0.0;cvi=0.0;adiabat=0.0
+wbar=0.0;alast=0.0;vhrel=0.0;virel=0.0  
+zsurf=0.0;zbase=0.0;ztop=0.0;area=0.0;rsurf=0.0;alpha=0.0;radius=0.0;heating=0.0
+fmoist=0.0;bload=0.0;dt=0.0;time=0.0;tdur=0.0
+ztop_=0.0
+upe =0.0  
+vpe =0.0  
+vel_e =0.0
+vel_p =0.0
+rad_p =0.0
+vel_t =0.0
+rad_t =0.0
+ W_VMD=0.0
+ VMD=0.0
+n=0;nm1=0;l=0;lbase=0;mintime=0;mdur=0;maxtime=0
+end subroutine zero_plumegen_coms
+end module plume_zero_mod


### PR DESCRIPTION
This PR:
- adds a missing CPP directive around `include "netcdf.inc"` to `Process_Library/Chem_MieTableMod2G.F90`
- adds the GSD chem plume rise modules and dependencies (constants, config)

In a future step, we definitely need to clean up these two modules `gsd_chem_constants` and `gsd_chem_config` - there should be one common place to define constants and configurations.

Associated PRs:

https://github.com/NOAA-GSL/ccpp-physics/pull/87
https://github.com/NOAA-GSL/fv3atm/pull/84
https://github.com/NOAA-GSL/GOCART/pull/2
https://github.com/NOAA-GSL/ufs-weather-model/pull/73

For testing, see https://github.com/NOAA-GSL/ufs-weather-model/pull/73.